### PR TITLE
fix(verify-platform): make _hc_bump_warn safe under set -e

### DIFF
--- a/scripts/verify-platform.sh
+++ b/scripts/verify-platform.sh
@@ -39,13 +39,13 @@ _hc_ok(){ if declare -F ok >/dev/null; then ok "$@"; else echo "OK: $*"; fi; }
 _hc_warn(){ if declare -F warn >/dev/null; then warn "$@"; else echo "WARN: $*" >&2; fi; }
 _hc_bump_warn(){
   if declare -F bump_warn >/dev/null; then
-    bump_warn
+    bump_warn || true
   else
     WARN_COUNT="${WARN_COUNT:-0}"; WARN_COUNT=$((WARN_COUNT+1))
     EXIT_CODE="${EXIT_CODE:-0}"; [ "$EXIT_CODE" -lt 1 ] && EXIT_CODE=1
   fi
+  return 0
 }
-
 health_checks() {
   _hc_section "Health reports"
 


### PR DESCRIPTION
Why: under set -e, _hc_bump_warn() could return non-zero when EXIT_CODE already set, aborting the script and skipping remaining checks.\n\nChange: ensure _hc_bump_warn() always returns 0; bump_warn is called as best-effort (|| true).\n\nProof: run scripts/verify-platform.sh (see /tmp/verify-platform.20260216-151638.log summary).