### PR TITLE
docs(readme): remove duplicate Gallery section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,30 +50,6 @@ bash scripts/verify-platform.sh
 
 ---
 
-## Gallery
-
-<p align="center">
-  <img src="pour_copilot/photos/LinuxIA_02.jpg" width="220" alt="LinuxIA_02" />
-  <img src="pour_copilot/photos/LinuxIA_03.jpg" width="220" alt="LinuxIA_03" />
-  <img src="pour_copilot/photos/LinuxIA_04.jpg" width="220" alt="LinuxIA_04" />
-  <img src="pour_copilot/photos/LinuxIA_05.jpg" width="220" alt="LinuxIA_05" />
-</p>
-
-<p align="center">
-  <img src="pour_copilot/photos/LinuxIA_06.jpg" width="220" alt="LinuxIA_06" />
-  <img src="pour_copilot/photos/LinuxIA_07.jpg" width="220" alt="LinuxIA_07" />
-  <img src="pour_copilot/photos/LinuxIA_08.jpg" width="220" alt="LinuxIA_08" />
-  <img src="pour_copilot/photos/LinuxIA_09.jpg" width="220" alt="LinuxIA_09" />
-</p>
-
-<p align="center">
-  <img src="pour_copilot/photos/LinuxIA_10.jpg" width="220" alt="LinuxIA_10" />
-  <img src="pour_copilot/photos/LinuxIA_11.jpg" width="220" alt="LinuxIA_11" />
-  <img src="pour_copilot/photos/LinuxIA_12.jpg" width="220" alt="LinuxIA_12" />
-</p>
-
----
-
 ## Media
 
 - 🎵 Theme: [Theme_01.mp3](pour_copilot/audio/Theme_01.mp3)


### PR DESCRIPTION
Suppression de l'ancienne section `## Gallery` (sans 'temporary small thumbnails') dupliquée avec la nouvelle.