### PR TITLE
docs(readme): improve SVG text contrast + remove redundant link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <p align="center">
   <img src="assets/readme/banner-linuxia.svg" width="1000" alt="LinuxIA animated banner" />
-<p align="center"><a href="assets/readme/banner-linuxia.svg">&#x25B6;&#xFE0F; Voir l'animation (SVG)</a></p>
 
 </p>
 

--- a/assets/readme/animations/anim_01_score90.svg
+++ b/assets/readme/animations/anim_01_score90.svg
@@ -1,4 +1,25 @@
 <svg width="100%" height="520" viewBox="0 0 1440 520" preserveAspectRatio="none">
+<defs>
+  <filter id="linuxiaTextShadow" x="-50%" y="-50%" width="200%" height="200%">
+    <feDropShadow dx="0" dy="2" stdDeviation="2.2" flood-color="#000000" flood-opacity="0.85"/>
+    <feDropShadow dx="0" dy="0" stdDeviation="1.2" flood-color="#000000" flood-opacity="0.70"/>
+  </filter>
+  <style><![CDATA[
+    text, tspan {
+      paint-order: stroke fill;
+      stroke: #000;
+      stroke-width: 6px;
+      stroke-linejoin: round;
+      stroke-linecap: round;
+      filter: url(#linuxiaTextShadow);
+    }
+    text[font-size="10"], text[font-size="11"], text[font-size="12"], text[font-size="13"], text[font-size="14"], text[font-size="15"] {
+      stroke-width: 4.5px;
+    }
+    rect.label-bg, rect[id*="label"], rect[class*="label"] { opacity: 0 !important; }
+  ]]></style>
+</defs>
+
 <style>
 /* LinuxIA label contrast patch */
 text{

--- a/assets/readme/animations/anim_02_score11.svg
+++ b/assets/readme/animations/anim_02_score11.svg
@@ -1,4 +1,25 @@
 <svg width="100%" height="60">
+<defs>
+  <filter id="linuxiaTextShadow" x="-50%" y="-50%" width="200%" height="200%">
+    <feDropShadow dx="0" dy="2" stdDeviation="2.2" flood-color="#000000" flood-opacity="0.85"/>
+    <feDropShadow dx="0" dy="0" stdDeviation="1.2" flood-color="#000000" flood-opacity="0.70"/>
+  </filter>
+  <style><![CDATA[
+    text, tspan {
+      paint-order: stroke fill;
+      stroke: #000;
+      stroke-width: 6px;
+      stroke-linejoin: round;
+      stroke-linecap: round;
+      filter: url(#linuxiaTextShadow);
+    }
+    text[font-size="10"], text[font-size="11"], text[font-size="12"], text[font-size="13"], text[font-size="14"], text[font-size="15"] {
+      stroke-width: 4.5px;
+    }
+    rect.label-bg, rect[id*="label"], rect[class*="label"] { opacity: 0 !important; }
+  ]]></style>
+</defs>
+
 <style>
 /* LinuxIA label contrast patch */
 text{

--- a/assets/readme/animations/anim_03_score9.svg
+++ b/assets/readme/animations/anim_03_score9.svg
@@ -1,4 +1,25 @@
 <svg width="100%" height="100">
+<defs>
+  <filter id="linuxiaTextShadow" x="-50%" y="-50%" width="200%" height="200%">
+    <feDropShadow dx="0" dy="2" stdDeviation="2.2" flood-color="#000000" flood-opacity="0.85"/>
+    <feDropShadow dx="0" dy="0" stdDeviation="1.2" flood-color="#000000" flood-opacity="0.70"/>
+  </filter>
+  <style><![CDATA[
+    text, tspan {
+      paint-order: stroke fill;
+      stroke: #000;
+      stroke-width: 6px;
+      stroke-linejoin: round;
+      stroke-linecap: round;
+      filter: url(#linuxiaTextShadow);
+    }
+    text[font-size="10"], text[font-size="11"], text[font-size="12"], text[font-size="13"], text[font-size="14"], text[font-size="15"] {
+      stroke-width: 4.5px;
+    }
+    rect.label-bg, rect[id*="label"], rect[class*="label"] { opacity: 0 !important; }
+  ]]></style>
+</defs>
+
 <style>
 /* LinuxIA label contrast patch */
 text{

--- a/assets/readme/animations/anim_04_score15.svg
+++ b/assets/readme/animations/anim_04_score15.svg
@@ -1,4 +1,25 @@
 <svg width="100%" height="100" viewBox="0 0 1440 100">
+<defs>
+  <filter id="linuxiaTextShadow" x="-50%" y="-50%" width="200%" height="200%">
+    <feDropShadow dx="0" dy="2" stdDeviation="2.2" flood-color="#000000" flood-opacity="0.85"/>
+    <feDropShadow dx="0" dy="0" stdDeviation="1.2" flood-color="#000000" flood-opacity="0.70"/>
+  </filter>
+  <style><![CDATA[
+    text, tspan {
+      paint-order: stroke fill;
+      stroke: #000;
+      stroke-width: 6px;
+      stroke-linejoin: round;
+      stroke-linecap: round;
+      filter: url(#linuxiaTextShadow);
+    }
+    text[font-size="10"], text[font-size="11"], text[font-size="12"], text[font-size="13"], text[font-size="14"], text[font-size="15"] {
+      stroke-width: 4.5px;
+    }
+    rect.label-bg, rect[id*="label"], rect[class*="label"] { opacity: 0 !important; }
+  ]]></style>
+</defs>
+
 <style>
 /* LinuxIA label contrast patch */
 text{

--- a/assets/readme/animations/anim_05_score25.svg
+++ b/assets/readme/animations/anim_05_score25.svg
@@ -1,4 +1,25 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+<defs>
+  <filter id="linuxiaTextShadow" x="-50%" y="-50%" width="200%" height="200%">
+    <feDropShadow dx="0" dy="2" stdDeviation="2.2" flood-color="#000000" flood-opacity="0.85"/>
+    <feDropShadow dx="0" dy="0" stdDeviation="1.2" flood-color="#000000" flood-opacity="0.70"/>
+  </filter>
+  <style><![CDATA[
+    text, tspan {
+      paint-order: stroke fill;
+      stroke: #000;
+      stroke-width: 6px;
+      stroke-linejoin: round;
+      stroke-linecap: round;
+      filter: url(#linuxiaTextShadow);
+    }
+    text[font-size="10"], text[font-size="11"], text[font-size="12"], text[font-size="13"], text[font-size="14"], text[font-size="15"] {
+      stroke-width: 4.5px;
+    }
+    rect.label-bg, rect[id*="label"], rect[class*="label"] { opacity: 0 !important; }
+  ]]></style>
+</defs>
+
 <style>
 /* LinuxIA label contrast patch */
 text{

--- a/assets/readme/animations/anim_06_score175.svg
+++ b/assets/readme/animations/anim_06_score175.svg
@@ -1,4 +1,25 @@
 <svg class="hero__svg" viewBox="0 0 1440 520" preserveAspectRatio="none" aria-hidden="true">
+<defs>
+  <filter id="linuxiaTextShadow" x="-50%" y="-50%" width="200%" height="200%">
+    <feDropShadow dx="0" dy="2" stdDeviation="2.2" flood-color="#000000" flood-opacity="0.85"/>
+    <feDropShadow dx="0" dy="0" stdDeviation="1.2" flood-color="#000000" flood-opacity="0.70"/>
+  </filter>
+  <style><![CDATA[
+    text, tspan {
+      paint-order: stroke fill;
+      stroke: #000;
+      stroke-width: 6px;
+      stroke-linejoin: round;
+      stroke-linecap: round;
+      filter: url(#linuxiaTextShadow);
+    }
+    text[font-size="10"], text[font-size="11"], text[font-size="12"], text[font-size="13"], text[font-size="14"], text[font-size="15"] {
+      stroke-width: 4.5px;
+    }
+    rect.label-bg, rect[id*="label"], rect[class*="label"] { opacity: 0 !important; }
+  ]]></style>
+</defs>
+
 <style>
 /* LinuxIA label contrast patch */
 text{

--- a/assets/readme/animations/anim_07_score11.svg
+++ b/assets/readme/animations/anim_07_score11.svg
@@ -1,4 +1,25 @@
 <svg width="100%" height="64" viewBox="0 0 1440 64" preserveAspectRatio="none">
+<defs>
+  <filter id="linuxiaTextShadow" x="-50%" y="-50%" width="200%" height="200%">
+    <feDropShadow dx="0" dy="2" stdDeviation="2.2" flood-color="#000000" flood-opacity="0.85"/>
+    <feDropShadow dx="0" dy="0" stdDeviation="1.2" flood-color="#000000" flood-opacity="0.70"/>
+  </filter>
+  <style><![CDATA[
+    text, tspan {
+      paint-order: stroke fill;
+      stroke: #000;
+      stroke-width: 6px;
+      stroke-linejoin: round;
+      stroke-linecap: round;
+      filter: url(#linuxiaTextShadow);
+    }
+    text[font-size="10"], text[font-size="11"], text[font-size="12"], text[font-size="13"], text[font-size="14"], text[font-size="15"] {
+      stroke-width: 4.5px;
+    }
+    rect.label-bg, rect[id*="label"], rect[class*="label"] { opacity: 0 !important; }
+  ]]></style>
+</defs>
+
 <style>
 /* LinuxIA label contrast patch */
 text{

--- a/assets/readme/animations/anim_08_score9.svg
+++ b/assets/readme/animations/anim_08_score9.svg
@@ -1,4 +1,25 @@
 <svg width="100%" height="72" viewBox="0 0 1440 72" preserveAspectRatio="none">
+<defs>
+  <filter id="linuxiaTextShadow" x="-50%" y="-50%" width="200%" height="200%">
+    <feDropShadow dx="0" dy="2" stdDeviation="2.2" flood-color="#000000" flood-opacity="0.85"/>
+    <feDropShadow dx="0" dy="0" stdDeviation="1.2" flood-color="#000000" flood-opacity="0.70"/>
+  </filter>
+  <style><![CDATA[
+    text, tspan {
+      paint-order: stroke fill;
+      stroke: #000;
+      stroke-width: 6px;
+      stroke-linejoin: round;
+      stroke-linecap: round;
+      filter: url(#linuxiaTextShadow);
+    }
+    text[font-size="10"], text[font-size="11"], text[font-size="12"], text[font-size="13"], text[font-size="14"], text[font-size="15"] {
+      stroke-width: 4.5px;
+    }
+    rect.label-bg, rect[id*="label"], rect[class*="label"] { opacity: 0 !important; }
+  ]]></style>
+</defs>
+
 <style>
 /* LinuxIA label contrast patch */
 text{

--- a/assets/readme/animations/anim_09_score422.svg
+++ b/assets/readme/animations/anim_09_score422.svg
@@ -1,4 +1,25 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1440" height="520" viewBox="0 0 1440 520" preserveAspectRatio="none">
+<defs>
+  <filter id="linuxiaTextShadow" x="-50%" y="-50%" width="200%" height="200%">
+    <feDropShadow dx="0" dy="2" stdDeviation="2.2" flood-color="#000000" flood-opacity="0.85"/>
+    <feDropShadow dx="0" dy="0" stdDeviation="1.2" flood-color="#000000" flood-opacity="0.70"/>
+  </filter>
+  <style><![CDATA[
+    text, tspan {
+      paint-order: stroke fill;
+      stroke: #000;
+      stroke-width: 6px;
+      stroke-linejoin: round;
+      stroke-linecap: round;
+      filter: url(#linuxiaTextShadow);
+    }
+    text[font-size="10"], text[font-size="11"], text[font-size="12"], text[font-size="13"], text[font-size="14"], text[font-size="15"] {
+      stroke-width: 4.5px;
+    }
+    rect.label-bg, rect[id*="label"], rect[class*="label"] { opacity: 0 !important; }
+  ]]></style>
+</defs>
+
 <style>
 /* LinuxIA label contrast patch */
 text{
@@ -183,7 +204,7 @@ text{
     <g>
       <circle r="6" fill="#00C8FF" opacity="0.92"/>
       <g class="label">
-  <rect x="4.00" y="-12.00" width="111.20" height="20.00" rx="4" fill="#000" opacity="0.55" />
+  <rect class="label-bg" x="4.00" y="-12.00" width="111.20" height="20.00" rx="4" fill="#000" opacity="0.55" />
   <text x="10" y="4" fill="#B9FFEE" opacity="0.95">FourmIAlux</text>
 </g>
       <animateMotion dur="26s" repeatCount="indefinite" rotate="0"><mpath href="#orbA"/></animateMotion>
@@ -191,7 +212,7 @@ text{
     <g>
       <circle r="6" fill="#FFD700" opacity="0.90"/>
       <g class="label">
-  <rect x="4.00" y="-12.00" width="111.20" height="20.00" rx="4" fill="#000" opacity="0.55" />
+  <rect class="label-bg" x="4.00" y="-12.00" width="111.20" height="20.00" rx="4" fill="#000" opacity="0.55" />
   <text x="10" y="4" fill="#FFD700" opacity="0.95">ChromIAlux</text>
 </g>
       <animateMotion dur="34s" repeatCount="indefinite" rotate="0"><mpath href="#orbB"/></animateMotion>
@@ -199,7 +220,7 @@ text{
     <g>
       <circle r="6" fill="#73BA25" opacity="0.90"/>
       <g class="label">
-  <rect x="4.00" y="-12.00" width="111.20" height="20.00" rx="4" fill="#000" opacity="0.55" />
+  <rect class="label-bg" x="4.00" y="-12.00" width="111.20" height="20.00" rx="4" fill="#000" opacity="0.55" />
   <text x="10" y="4" fill="#73BA25" opacity="0.95">Trio LuxIA</text>
 </g>
       <animateMotion dur="42s" repeatCount="indefinite" rotate="0"><mpath href="#orbC"/></animateMotion>
@@ -267,17 +288,17 @@ text{
   <!-- Text -->
   <g filter="url(#txtGlow)" font-family="ui-sans-serif, system-ui, Segoe UI, Roboto">
     <g class="label">
-  <rect x="714.00" y="92.00" width="350.52" height="97.50" rx="4" fill="#000" opacity="0.55" />
+  <rect class="label-bg" x="714.00" y="92.00" width="350.52" height="97.50" rx="4" fill="#000" opacity="0.55" />
   <text x="720" y="170" text-anchor="middle" font-size="78" fill="#EAF7FF" opacity="0.98" letter-spacing="1.5">LinuxIA</text>
 </g>
     <g class="label">
-  <rect x="714.00" y="196.00" width="715.08" height="22.50" rx="4" fill="#000" opacity="0.55" />
+  <rect class="label-bg" x="714.00" y="196.00" width="715.08" height="22.50" rx="4" fill="#000" opacity="0.55" />
   <text x="720" y="214" text-anchor="middle" font-size="18" fill="#B9FFEE" opacity="0.94">
       Proof-first • Multi-VM • CI • Audit • Orchestration
     </text>
 </g>
     <g class="label">
-  <rect x="714.00" y="230.00" width="610.92" height="17.50" rx="4" fill="#000" opacity="0.55" />
+  <rect class="label-bg" x="714.00" y="230.00" width="610.92" height="17.50" rx="4" fill="#000" opacity="0.55" />
   <text x="720" y="244" text-anchor="middle" font-size="14" fill="#FFD700" opacity="0.90">
       Aucun changement sans preuve — seulement ce qui est fait.
     </text>

--- a/assets/readme/banner-linuxia.svg
+++ b/assets/readme/banner-linuxia.svg
@@ -1,4 +1,25 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1440" height="520" viewBox="0 0 1440 520" preserveAspectRatio="none">
+<defs>
+  <filter id="linuxiaTextShadow" x="-50%" y="-50%" width="200%" height="200%">
+    <feDropShadow dx="0" dy="2" stdDeviation="2.2" flood-color="#000000" flood-opacity="0.85"/>
+    <feDropShadow dx="0" dy="0" stdDeviation="1.2" flood-color="#000000" flood-opacity="0.70"/>
+  </filter>
+  <style><![CDATA[
+    text, tspan {
+      paint-order: stroke fill;
+      stroke: #000;
+      stroke-width: 6px;
+      stroke-linejoin: round;
+      stroke-linecap: round;
+      filter: url(#linuxiaTextShadow);
+    }
+    text[font-size="10"], text[font-size="11"], text[font-size="12"], text[font-size="13"], text[font-size="14"], text[font-size="15"] {
+      stroke-width: 4.5px;
+    }
+    rect.label-bg, rect[id*="label"], rect[class*="label"] { opacity: 0 !important; }
+  ]]></style>
+</defs>
+
 <style>
 /* LinuxIA label contrast patch */
 text{
@@ -183,7 +204,7 @@ text{
     <g>
       <circle r="6" fill="#00C8FF" opacity="0.92"/>
       <g class="label">
-  <rect x="4.00" y="-12.00" width="111.20" height="20.00" rx="4" fill="#000" opacity="0.55" />
+  <rect class="label-bg" x="4.00" y="-12.00" width="111.20" height="20.00" rx="4" fill="#000" opacity="0.55" />
   <text x="10" y="4" fill="#B9FFEE" opacity="0.95">FourmIAlux</text>
 </g>
       <animateMotion dur="26s" repeatCount="indefinite" rotate="0"><mpath href="#orbA"/></animateMotion>
@@ -191,7 +212,7 @@ text{
     <g>
       <circle r="6" fill="#FFD700" opacity="0.90"/>
       <g class="label">
-  <rect x="4.00" y="-12.00" width="111.20" height="20.00" rx="4" fill="#000" opacity="0.55" />
+  <rect class="label-bg" x="4.00" y="-12.00" width="111.20" height="20.00" rx="4" fill="#000" opacity="0.55" />
   <text x="10" y="4" fill="#FFD700" opacity="0.95">ChromIAlux</text>
 </g>
       <animateMotion dur="34s" repeatCount="indefinite" rotate="0"><mpath href="#orbB"/></animateMotion>
@@ -199,7 +220,7 @@ text{
     <g>
       <circle r="6" fill="#73BA25" opacity="0.90"/>
       <g class="label">
-  <rect x="4.00" y="-12.00" width="111.20" height="20.00" rx="4" fill="#000" opacity="0.55" />
+  <rect class="label-bg" x="4.00" y="-12.00" width="111.20" height="20.00" rx="4" fill="#000" opacity="0.55" />
   <text x="10" y="4" fill="#73BA25" opacity="0.95">Trio LuxIA</text>
 </g>
       <animateMotion dur="42s" repeatCount="indefinite" rotate="0"><mpath href="#orbC"/></animateMotion>
@@ -267,17 +288,17 @@ text{
   <!-- Text -->
   <g filter="url(#txtGlow)" font-family="ui-sans-serif, system-ui, Segoe UI, Roboto">
     <g class="label">
-  <rect x="714.00" y="92.00" width="350.52" height="97.50" rx="4" fill="#000" opacity="0.55" />
+  <rect class="label-bg" x="714.00" y="92.00" width="350.52" height="97.50" rx="4" fill="#000" opacity="0.55" />
   <text x="720" y="170" text-anchor="middle" font-size="78" fill="#EAF7FF" opacity="0.98" letter-spacing="1.5">LinuxIA</text>
 </g>
     <g class="label">
-  <rect x="714.00" y="196.00" width="715.08" height="22.50" rx="4" fill="#000" opacity="0.55" />
+  <rect class="label-bg" x="714.00" y="196.00" width="715.08" height="22.50" rx="4" fill="#000" opacity="0.55" />
   <text x="720" y="214" text-anchor="middle" font-size="18" fill="#B9FFEE" opacity="0.94">
       Proof-first • Multi-VM • CI • Audit • Orchestration
     </text>
 </g>
     <g class="label">
-  <rect x="714.00" y="230.00" width="610.92" height="17.50" rx="4" fill="#000" opacity="0.55" />
+  <rect class="label-bg" x="714.00" y="230.00" width="610.92" height="17.50" rx="4" fill="#000" opacity="0.55" />
   <text x="720" y="244" text-anchor="middle" font-size="14" fill="#FFD700" opacity="0.90">
       Aucun changement sans preuve — seulement ce qui est fait.
     </text>


### PR DESCRIPTION
Passe les SVG en contraste robuste (stroke+shadow sur text) pour eviter le rectangle noir decale, et supprime le lien 'Voir l animation (SVG)' devenu inutile.