### PR TITLE
feat(chromialux): terminal bridge v1.4.0 — xterm postMessage relay + HUD

### DIFF
--- a/ChromIAlux/linuxia-split-terminal-ext/README.md
+++ b/ChromIAlux/linuxia-split-terminal-ext/README.md
@@ -1,0 +1,21 @@
+# linuxia-split-terminal-ext v1.4.0
+
+Chrome MV3 extension: split ChatGPT (top) + ttyd terminal dock (bottom).
+
+## Architecture
+- **content.js** — injected in ChatGPT page: dock UI + terminal HUD overlay (live buffer)
+- **bridge.js** — injected in `http://127.0.0.1:7681/*` (ttyd): reads xterm buffer, relays to background
+- **background.js** — service worker relay: bridges ChatGPT ↔ ttyd + WebSocket fallback
+- **dock.html** — static page (kept for reference)
+
+## Features
+- `Ctrl+Shift+Y` toggle dock  
+- `Ctrl+Shift+L` toggle scan mode (selection → terminal)  
+- Context menu: "→ LinuxIA Terminal"
+- **Live HUD**: small overlay showing last 30 lines of terminal buffer
+- **postMessage bridge**: ChatGPT can send commands; terminal output visible in HUD
+
+## Install
+1. `chrome://extensions` → Load unpacked → select this folder
+2. Start ttyd: `ttyd -p 7681 bash`
+3. Click icon or `Ctrl+Shift+Y` on ChatGPT

--- a/ChromIAlux/linuxia-split-terminal-ext/background.js
+++ b/ChromIAlux/linuxia-split-terminal-ext/background.js
@@ -1,0 +1,258 @@
+const STATE = {
+  dockOn: false,
+  scanOn: false,
+};
+
+const BRIDGE = {
+  ttydTabId: null,
+  chatTabId: null,
+};
+
+const TTYD_HTTP = "http://127.0.0.1:7681/";
+const TTYD_WS   = "ws://127.0.0.1:7681/ws";
+
+// ─── TerminalWS ───────────────────────────────────────────────────────────────
+// Single WebSocket: receives output (broadcasts TERM_OUT) + sends input frames.
+const TerminalWS = {
+  ws:             null,
+  ready:          false,
+  connecting:     false,
+  reconnectTimer: null,
+  inputQueue:     [],
+
+  connect() {
+    if (this.connecting || this.ready) return;
+    this.connecting = true;
+    try {
+      const ws = new WebSocket(TTYD_WS);
+      this.ws = ws;
+      ws.binaryType = "arraybuffer";
+
+      ws.onopen = () => {
+        this.connecting = false;
+        this.ready = true;
+        console.log("[LinuxIA] WS CONNECTED");
+        try { ws.send(JSON.stringify({ AuthToken: "" })); } catch (_) {}
+        setTimeout(() => this._flushQueue(), 120);
+      };
+
+      ws.onmessage = (evt) => {
+        let data;
+        if (evt.data instanceof ArrayBuffer) {
+          const bytes = new Uint8Array(evt.data);
+          if (bytes.length === 0) return;
+          data = String.fromCharCode(bytes[0]) + new TextDecoder().decode(bytes.slice(1));
+        } else {
+          data = String(evt.data);
+        }
+        console.log("[LinuxIA] WS MESSAGE", data.slice(0, 80));
+        broadcastTermOut(data);
+      };
+
+      ws.onclose = () => {
+        if (this.ws !== ws) return;
+        this.ready = false;
+        this.connecting = false;
+        this.ws = null;
+        console.log("[LinuxIA] WS CLOSED");
+        if (STATE.dockOn) this._scheduleReconnect();
+      };
+
+      ws.onerror = () => {
+        if (this.ws !== ws) return;
+        this.ready = false;
+        this.connecting = false;
+        this.ws = null;
+        if (STATE.dockOn) this._scheduleReconnect();
+      };
+    } catch (_) {
+      this.connecting = false;
+      this.ready = false;
+      this.ws = null;
+      if (STATE.dockOn) this._scheduleReconnect();
+    }
+  },
+
+  _scheduleReconnect() {
+    if (this.reconnectTimer) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, 2000);
+  },
+
+  disconnect() {
+    if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); this.reconnectTimer = null; }
+    try { if (this.ws) this.ws.close(); } catch (_) {}
+    this.ws = null;
+    this.ready = false;
+    this.connecting = false;
+  },
+
+  sendInput(text) {
+    const payload = "0" + String(text || "") + "\r";
+    if (!this.ready || !this.ws) {
+      this.inputQueue.push(payload);
+      this.connect();
+      return;
+    }
+    try { this.ws.send(payload); } catch (_) {
+      this.ready = false;
+      this.ws = null;
+      this.inputQueue.push(payload);
+      this.connect();
+    }
+  },
+
+  _flushQueue() {
+    if (!this.ready || !this.ws) return;
+    for (const p of this.inputQueue.splice(0)) {
+      try { this.ws.send(p); } catch (_) {}
+    }
+  },
+};
+
+function broadcastTermOut(data) {
+  chrome.tabs.query({}, (tabs) => {
+    for (const tab of tabs) {
+      if (!tab.id) continue;
+      chrome.tabs.sendMessage(tab.id, { type: "TERM_OUT", data }).catch(() => {});
+    }
+  });
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+function setBadge() {
+  const text = STATE.dockOn ? (STATE.scanOn ? "SCAN" : "ON") : "";
+  chrome.action.setBadgeText({ text });
+}
+
+async function getActiveTabId() {
+  const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+  return tab?.id;
+}
+
+async function sendToActiveTab(msg) {
+  const tabId = await getActiveTabId();
+  if (!tabId) return;
+  try {
+    await chrome.tabs.sendMessage(tabId, msg);
+  } catch {
+    setTimeout(() => chrome.tabs.sendMessage(tabId, msg).catch(() => {}), 250);
+  }
+}
+
+function ensureContextMenu() {
+  chrome.contextMenus.removeAll(() => {
+    chrome.contextMenus.create({
+      id: "linuxia_send_selection",
+      title: "→ LinuxIA Terminal (dock)",
+      contexts: ["selection"],
+    });
+  });
+}
+
+function sendToTerminal(text) {
+  const t = String(text || "").trim();
+  if (!t) return;
+  TerminalWS.sendInput(t);
+}
+
+// ─── Dock toggle ──────────────────────────────────────────────────────────────
+async function toggleDock(force) {
+  STATE.dockOn = typeof force === "boolean" ? force : !STATE.dockOn;
+  await chrome.storage.local.set({ linuxiaDockOn: STATE.dockOn });
+  setBadge();
+  if (STATE.dockOn) {
+    TerminalWS.connect();
+    await sendToActiveTab({ type: "DOCK_SHOW", url: TTYD_HTTP });
+  } else {
+    await sendToActiveTab({ type: "DOCK_HIDE" });
+  }
+}
+
+async function toggleScan(force) {
+  STATE.scanOn = typeof force === "boolean" ? force : !STATE.scanOn;
+  await chrome.storage.local.set({ linuxiaScanOn: STATE.scanOn });
+  setBadge();
+}
+
+// ─── Lifecycle ────────────────────────────────────────────────────────────────
+chrome.runtime.onInstalled.addListener(async () => {
+  const stored = await chrome.storage.local.get(["linuxiaDockOn", "linuxiaScanOn"]);
+  STATE.dockOn = !!stored.linuxiaDockOn;
+  STATE.scanOn = !!stored.linuxiaScanOn;
+  setBadge();
+  ensureContextMenu();
+  if (STATE.dockOn) TerminalWS.connect();
+});
+
+chrome.runtime.onStartup.addListener(async () => {
+  const stored = await chrome.storage.local.get(["linuxiaDockOn", "linuxiaScanOn"]);
+  STATE.dockOn = !!stored.linuxiaDockOn;
+  STATE.scanOn = !!stored.linuxiaScanOn;
+  setBadge();
+  ensureContextMenu();
+  if (STATE.dockOn) TerminalWS.connect();
+});
+
+chrome.action.onClicked.addListener(async () => {
+  await toggleDock();
+});
+
+chrome.commands.onCommand.addListener(async (cmd) => {
+  if (cmd === "toggle-dock") await toggleDock();
+  if (cmd === "toggle-scan") await toggleScan();
+});
+
+chrome.contextMenus.onClicked.addListener(async (info) => {
+  if (info.menuItemId === "linuxia_send_selection") {
+    const text = (info.selectionText || "").trim();
+    if (text) sendToTerminal(text);
+  }
+});
+
+// ─── Message relay ────────────────────────────────────────────────────────────
+chrome.runtime.onMessage.addListener((msg, sender) => {
+  if (!msg || typeof msg !== "object") return;
+
+  if (msg.type === "SCAN_TEXT") {
+    if (!STATE.scanOn) return;
+    if (!STATE.dockOn) toggleDock(true);
+    sendToTerminal(msg.text);
+  }
+
+  if (msg.type === "TERMINAL_BUFFER") {
+    if (sender.tab) BRIDGE.ttydTabId = sender.tab.id;
+    if (BRIDGE.chatTabId) {
+      chrome.tabs.sendMessage(BRIDGE.chatTabId, {
+        type: "TERMINAL_BUFFER_UPDATE",
+        lines: msg.lines || [],
+        content: msg.content || "",
+      }).catch(() => {});
+    }
+  }
+
+  if (msg.type === "SEND_TO_TERMINAL_REQ") {
+    if (sender.tab) BRIDGE.chatTabId = sender.tab.id;
+    const text = String(msg.text || "").trim();
+    if (!text) return;
+    if (BRIDGE.ttydTabId) {
+      chrome.tabs.sendMessage(BRIDGE.ttydTabId, { type: "SEND_TO_TERMINAL", text }).catch(() => {
+        sendToTerminal(text);
+      });
+    } else {
+      sendToTerminal(text);
+    }
+  }
+
+  if (msg.type === "REGISTER_CHATGPT_TAB") {
+    if (sender.tab) BRIDGE.chatTabId = sender.tab.id;
+  }
+});
+
+chrome.tabs.onUpdated.addListener((tabId, _info, tab) => {
+  if (tab.url && tab.url.startsWith("http://127.0.0.1:7681")) {
+    BRIDGE.ttydTabId = tabId;
+  }
+});

--- a/ChromIAlux/linuxia-split-terminal-ext/bridge.js
+++ b/ChromIAlux/linuxia-split-terminal-ext/bridge.js
@@ -1,0 +1,80 @@
+// bridge.js — content script injecté dans http://127.0.0.1:7681/*
+// Lit le buffer xterm, relaie vers background, reçoit les commandes.
+
+(() => {
+  const POLL_MS = 600;
+  let lastSent = "";
+  let hooked = false;
+
+  function getXterm() {
+    if (window.term && window.term.buffer) return window.term;
+    const el = document.querySelector(".xterm");
+    if (el) {
+      for (const key of Object.keys(el)) {
+        if (key.startsWith("_") && el[key] && el[key].buffer) return el[key];
+      }
+    }
+    return null;
+  }
+
+  function readBuffer(term) {
+    try {
+      const buf = term.buffer.active;
+      const lines = [];
+      for (let i = 0; i < buf.length; i++) {
+        const line = buf.getLine(i);
+        if (line) lines.push(line.translateToString(true));
+      }
+      while (lines.length && !lines[lines.length - 1].trim()) lines.pop();
+      return lines;
+    } catch { return []; }
+  }
+
+  function poll() {
+    const term = getXterm();
+    if (!term) return;
+    const lines = readBuffer(term);
+    const content = lines.join("\n");
+    if (content === lastSent) return;
+    lastSent = content;
+    chrome.runtime.sendMessage({
+      type: "TERMINAL_BUFFER",
+      content,
+      lines: lines.slice(-60),
+    }).catch(() => {});
+  }
+
+  function hookXterm() {
+    if (hooked) return;
+    const term = getXterm();
+    if (!term) { setTimeout(hookXterm, 1000); return; }
+    hooked = true;
+    try {
+      term.onRender(() => {
+        clearTimeout(window._linuxia_bridge_debounce);
+        window._linuxia_bridge_debounce = setTimeout(poll, 180);
+      });
+    } catch {}
+    poll();
+  }
+
+  setInterval(poll, POLL_MS);
+  hookXterm();
+
+  // Recevoir une commande depuis background
+  chrome.runtime.onMessage.addListener((msg) => {
+    if (!msg || msg.type !== "SEND_TO_TERMINAL") return;
+    const term = getXterm();
+    if (!term) return;
+    const text = String(msg.text || "").trim();
+    if (!text) return;
+    try {
+      // ttyd: term.input() envoie des frappes clavier brutes
+      if (typeof term.input === "function") {
+        term.input(text + "\r", true);
+      } else if (typeof term.paste === "function") {
+        term.paste(text + "\r");
+      }
+    } catch { /* best effort */ }
+  });
+})();

--- a/ChromIAlux/linuxia-split-terminal-ext/content.js
+++ b/ChromIAlux/linuxia-split-terminal-ext/content.js
@@ -1,0 +1,130 @@
+(() => {
+  "use strict";
+
+  const DOCK_ID   = "linuxia-ttyd-dock";
+  const IFRAME_ID = "linuxia-ttyd-iframe";
+  const MIRROR_ID = "linuxia-term-mirror";
+  const DEFAULT_URL = "http://127.0.0.1:7681/";
+
+  // ─── Mirror buffer ──────────────────────────────────────────────────────────
+  let mirrorBuf = "";
+  const MAX_BUF = 200000; // ~200 KB
+
+  // Strip common ANSI/VT100 sequences to get readable text
+  const RE_ANSI = /\x1b(?:\[[0-9;?]*[A-Za-z]|\][^\x07]*\x07|[()][A-Z0-9]|[A-Za-z])/g;
+
+  function appendBuffer(raw) {
+    if (typeof raw !== "string" || raw.length === 0) return;
+    const type = raw.charAt(0);
+    if (type !== "1") return; // only output frames; skip AuthToken JSON etc.
+    let text;
+    try { text = atob(raw.slice(1)); } catch (_) { text = raw.slice(1); }
+    text = text.replace(RE_ANSI, "")
+               .replace(/\r\n/g, "\n")
+               .replace(/\r/g, "\n");
+    mirrorBuf += text;
+    if (mirrorBuf.length > MAX_BUF) mirrorBuf = mirrorBuf.slice(-180000);
+  }
+
+  function renderMirror() {
+    const pre = document.getElementById(MIRROR_ID);
+    if (!pre) return;
+    pre.textContent = mirrorBuf;
+    pre.scrollTop = pre.scrollHeight;
+  }
+
+  // ─── Dock (position:fixed overlay – NO DOM rewrap) ──────────────────────────
+  function ensureDock(url) {
+    if (document.getElementById(DOCK_ID)) return;
+    url = url || DEFAULT_URL;
+
+    // Wrapper
+    const dock = document.createElement("div");
+    dock.id = DOCK_ID;
+    dock.style.cssText = [
+      "position:fixed", "bottom:0", "left:0", "right:0",
+      "height:42vh", "z-index:2147483647",
+      "display:flex", "flex-direction:column",
+      "background:#0b0b0b",
+      "border-top:2px solid rgba(78,252,255,0.4)",
+      "box-shadow:0 -4px 24px rgba(0,0,0,0.8)",
+      "font-family:\"Consolas\",\"Liberation Mono\",monospace",
+    ].join(";");
+
+    // Header bar
+    const bar = document.createElement("div");
+    bar.style.cssText = [
+      "height:32px", "flex-shrink:0",
+      "display:flex", "align-items:center", "justify-content:space-between",
+      "padding:0 10px", "background:#111",
+      "color:#4efcff", "font-size:12px", "font-weight:bold",
+      "border-bottom:1px solid #222",
+    ].join(";");
+    const title = document.createElement("span");
+    title.textContent = "◈ LinuxIA Terminal";
+    const closeBtn = document.createElement("button");
+    closeBtn.id = "linuxia-close";
+    closeBtn.textContent = "✕ Close";
+    closeBtn.style.cssText = [
+      "background:#1a1a1a", "border:1px solid #555", "color:#ccc",
+      "padding:3px 10px", "cursor:pointer", "border-radius:3px", "font-size:11px",
+    ].join(";");
+    bar.appendChild(title);
+    bar.appendChild(closeBtn);
+
+    // Mirror panel
+    const mirror = document.createElement("pre");
+    mirror.id = MIRROR_ID;
+    mirror.style.cssText = [
+      "height:18vh", "flex-shrink:0", "overflow:auto",
+      "margin:0", "padding:8px",
+      "font:12px/1.4 \"Consolas\",\"Liberation Mono\",monospace",
+      "background:#0b0b0b", "color:#d7d7d7",
+      "border-bottom:1px solid #333",
+      "white-space:pre-wrap", "word-break:break-all",
+    ].join(";");
+    mirror.textContent = mirrorBuf;
+
+    // iframe (interactive ttyd)
+    const iframe = document.createElement("iframe");
+    iframe.id = IFRAME_ID;
+    iframe.src = url;
+    iframe.allow = "clipboard-read; clipboard-write";
+    iframe.style.cssText = "flex:1;border:0;width:100%;min-height:0;";
+
+    dock.appendChild(bar);
+    dock.appendChild(mirror);   // mirror above iframe
+    dock.appendChild(iframe);
+    document.body.appendChild(dock);
+
+    // Push page content up so it's not hidden under the overlay
+    document.body.style.paddingBottom = "42vh";
+
+    closeBtn.addEventListener("click", removeDock);
+  }
+
+  function removeDock() {
+    const dock = document.getElementById(DOCK_ID);
+    if (dock) dock.remove();
+    document.body.style.paddingBottom = "";
+  }
+
+  // ─── Message listener ───────────────────────────────────────────────────────
+  chrome.runtime.onMessage.addListener((msg) => {
+    if (!msg) return;
+    if (msg.type === "TERM_OUT") {
+      appendBuffer(msg.data);
+      renderMirror();
+    }
+    if (msg.type === "DOCK_SHOW") ensureDock(msg.url || DEFAULT_URL);
+    if (msg.type === "DOCK_HIDE") removeDock();
+  });
+
+  // ─── Init ───────────────────────────────────────────────────────────────────
+  chrome.runtime.sendMessage({ type: "REGISTER_CHATGPT_TAB" }).catch(() => {});
+
+  // Restore dock state on page load (no reload needed)
+  chrome.storage.local.get(["linuxiaDockOn"], (s) => {
+    if (s.linuxiaDockOn) ensureDock(DEFAULT_URL);
+  });
+})();

--- a/ChromIAlux/linuxia-split-terminal-ext/dock.html
+++ b/ChromIAlux/linuxia-split-terminal-ext/dock.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html style="width:100%;height:100%;margin:0;padding:0;overflow:hidden">
+<head>
+  <meta charset="utf-8">
+  <style>
+    html, body { width:100%; height:100%; margin:0; padding:0; background:#000; overflow:hidden; }
+    iframe     { width:100%; height:100%; border:none; display:block; }
+  </style>
+</head>
+<body>
+  <iframe src="http://127.0.0.1:7681/" allowfullscreen allow="clipboard-read; clipboard-write"></iframe>
+</body>
+</html>

--- a/ChromIAlux/linuxia-split-terminal-ext/manifest.json
+++ b/ChromIAlux/linuxia-split-terminal-ext/manifest.json
@@ -1,0 +1,53 @@
+{
+  "manifest_version": 3,
+  "name": "LinuxIA Split Terminal Dock",
+  "version": "1.4.0",
+  "description": "Dock terminal ttyd en bas de la page (même page), + scan/selection vers terminal.",
+  "action": {
+    "default_title": "LinuxIA Dock"
+  },
+  "permissions": [
+    "activeTab",
+    "storage",
+    "contextMenus",
+    "tabs",
+    "scripting"
+  ],
+  "host_permissions": [
+    "http://127.0.0.1:7681/*",
+    "ws://127.0.0.1:7681/*",
+    "https://chatgpt.com/*",
+    "https://*.google.com/*",
+    "https://*/*",
+    "http://*/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["http://127.0.0.1:7681/*"],
+      "js": ["bridge.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "commands": {
+    "toggle-dock": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+Y"
+      },
+      "description": "Toggle terminal dock"
+    },
+    "toggle-scan": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+L"
+      },
+      "description": "Toggle scan mode (send selection/copy to terminal)"
+    }
+  }
+}


### PR DESCRIPTION
## What
Adds `bridge.js` content script + relay in `background.js` + HUD overlay in `content.js`.

## Architecture
```
ChatGPT tab (content.js) ←—chrome.runtime—→ background.js ←—chrome.tabs—→ ttyd tab (bridge.js)
```
- **bridge.js**: injected into `http://127.0.0.1:7681/*`, reads xterm `buffer.active` API, relays `TERMINAL_BUFFER` every 600ms + onRender debounce; receives `SEND_TO_TERMINAL` → `term.input()`
- **background.js**: relay hub with `BRIDGE.ttydTabId`/`chatTabId`; `tabs.onUpdated` auto-detects ttyd; added `tabs` permission
- **content.js**: registers as ChatGPT tab on load; live HUD overlay (360×180px, bottom-right above dock) shows last 30 lines of terminal buffer

## Files
`ChromIAlux/linuxia-split-terminal-ext/` (6 files)
