### PR TITLE
docs(readme): Hub Animations final — NASA/MATRIX HUD v2

### DIFF
--- a/assets/readme/anims/anim_01.svg
+++ b/assets/readme/anims/anim_01.svg
@@ -1,46 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="320" height="320" viewBox="0 0 320 320">
   <defs>
-    <linearGradient id="bg1" x1="0" y1="0" x2="1" y2="1">
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#050713"/>
       <stop offset="1" stop-color="#0b1430"/>
     </linearGradient>
-    <pattern id="grid1" patternUnits="userSpaceOnUse" width="28" height="28">
+    <radialGradient id="vign" cx="50%" cy="45%" r="75%">
+      <stop offset="0" stop-color="#000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000" stop-opacity="0.55"/>
+    </radialGradient>
+    <pattern id="grid" patternUnits="userSpaceOnUse" width="28" height="28">
       <path d="M28 0H0V28" fill="none" stroke="#7aa7ff" stroke-opacity="0.09" stroke-width="1"/>
     </pattern>
-    <pattern id="scan1" patternUnits="userSpaceOnUse" width="6" height="6">
+    <pattern id="scan" patternUnits="userSpaceOnUse" width="6" height="6">
       <rect width="6" height="6" fill="none"/>
       <rect y="0" width="6" height="1" fill="#ffffff" opacity="0.230"/>
     </pattern>
-    <filter id="glow1" x="-40%" y="-40%" width="180%" height="180%">
+    <filter id="glowC" x="-40%" y="-40%" width="180%" height="180%">
       <feGaussianBlur stdDeviation="3.8" result="b"/>
-      <feComposite in="b" in2="SourceGraphic" operator="over"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0
+                0 1 0 0 0.22
+                0 0 1 0 0.70
+                0 0 0 0.95 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowO" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="4.2" result="b"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0.12
+                0 1 0 0 0.04
+                0 0 1 0 0
+                0 0 0 0.85 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#000" flood-opacity="0.55"/>
     </filter>
   </defs>
-  <!-- background -->
-  <rect width="320" height="320" fill="url(#bg1)"/>
-  <rect width="320" height="320" fill="url(#grid1)"/>
-  <rect width="320" height="320" fill="url(#scan1)"/>
-  <!-- stars -->
-  <circle cx="29" cy="21" r="1.35" fill="#ff7a18" opacity="0.33"/><circle cx="66" cy="74" r="1.90" fill="#b36bff" opacity="0.49"/><circle cx="103" cy="127" r="0.80" fill="#ffffff" opacity="0.25"/><circle cx="140" cy="180" r="1.35" fill="#4efcff" opacity="0.41"/><circle cx="177" cy="233" r="1.90" fill="#ff7a18" opacity="0.57"/><circle cx="214" cy="286" r="0.80" fill="#b36bff" opacity="0.33"/><circle cx="251" cy="39" r="1.35" fill="#ffffff" opacity="0.49"/><circle cx="288" cy="92" r="1.90" fill="#4efcff" opacity="0.25"/><circle cx="25" cy="145" r="0.80" fill="#ff7a18" opacity="0.41"/><circle cx="62" cy="198" r="1.35" fill="#b36bff" opacity="0.57"/><circle cx="99" cy="251" r="1.90" fill="#ffffff" opacity="0.33"/><circle cx="136" cy="304" r="0.80" fill="#4efcff" opacity="0.49"/><circle cx="173" cy="57" r="1.35" fill="#ff7a18" opacity="0.25"/><circle cx="210" cy="110" r="1.90" fill="#b36bff" opacity="0.41"/><circle cx="247" cy="163" r="0.80" fill="#ffffff" opacity="0.57"/><circle cx="284" cy="216" r="1.35" fill="#4efcff" opacity="0.33"/><circle cx="21" cy="269" r="1.90" fill="#ff7a18" opacity="0.49"/><circle cx="58" cy="22" r="0.80" fill="#b36bff" opacity="0.25"/>
-  <!-- orbit rings -->
-  <ellipse cx="160.0" cy="160.0" rx="100" ry="74" fill="none" stroke="#4efcff" stroke-opacity="0.18" stroke-width="1.5" stroke-dasharray="4 6"/>
-  <ellipse cx="160.0" cy="160.0" rx="80" ry="60" fill="none" stroke="#ff8c00" stroke-opacity="0.12" stroke-width="1"/>
-  <!-- HUD ticks -->
-  <line x1="246.00" y1="160.00" x2="264.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="239.45" y1="192.91" x2="256.08" y2="199.80" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="220.81" y1="220.81" x2="233.54" y2="233.54" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="192.91" y1="239.45" x2="199.80" y2="256.08" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="246.00" x2="160.00" y2="264.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="127.09" y1="239.45" x2="120.20" y2="256.08" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="99.19" y1="220.81" x2="86.46" y2="233.54" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="80.55" y1="192.91" x2="63.92" y2="199.80" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="74.00" y1="160.00" x2="56.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="80.55" y1="127.09" x2="63.92" y2="120.20" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="99.19" y1="99.19" x2="86.46" y2="86.46" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="127.09" y1="80.55" x2="120.20" y2="63.92" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="74.00" x2="160.00" y2="56.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="192.91" y1="80.55" x2="199.80" y2="63.92" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="220.81" y1="99.19" x2="233.54" y2="86.46" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="239.45" y1="127.09" x2="256.08" y2="120.20" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/>
-  <!-- center sphere -->
-  <circle cx="160.0" cy="160.0" r="22" fill="#0b1a3a" stroke="#4efcff" stroke-opacity="0.5" stroke-width="1.8"/>
-  <circle cx="160.0" cy="160.0" r="8" fill="#4efcff" opacity="0.18"/>
-  <text x="160.0" y="164.0" text-anchor="middle" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.7">CORE</text>
-  <!-- orbiting dot (SMIL) -->
-  <circle cx="260.00" cy="160.00" r="5.5" fill="#4efcff" filter="url(#glow1)">
-    <animateTransform attributeName="transform" type="rotate"
-      from="0 160.0 160.0" to="360 160.0 160.0"
-      dur="3.35s" repeatCount="indefinite"/>
-  </circle>
-  <!-- data bars -->
-  <rect x="26" y="261" width="8" height="9" fill="#4efcff" opacity="0.25" rx="1"/><rect x="40" y="252" width="8" height="18" fill="#4efcff" opacity="0.32" rx="1"/><rect x="54" y="264" width="8" height="6" fill="#4efcff" opacity="0.39" rx="1"/><rect x="68" y="255" width="8" height="15" fill="#4efcff" opacity="0.18" rx="1"/><rect x="82" y="246" width="8" height="24" fill="#4efcff" opacity="0.25" rx="1"/><rect x="96" y="258" width="8" height="12" fill="#4efcff" opacity="0.32" rx="1"/><rect x="110" y="249" width="8" height="21" fill="#4efcff" opacity="0.39" rx="1"/><rect x="124" y="261" width="8" height="9" fill="#4efcff" opacity="0.18" rx="1"/><rect x="138" y="252" width="8" height="18" fill="#4efcff" opacity="0.25" rx="1"/>
-  <!-- label -->
-  <text x="10" y="14" font-family="monospace" font-size="9" fill="#ff8c00" opacity="0.7">SYS-01</text>
-  <text x="10" y="26" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.45">LINUXIA · HUB</text>
+  <rect width="320" height="320" fill="url(#bg)"/>
+  <rect width="320" height="320" fill="url(#grid)"/>
+  <rect width="320" height="320" fill="url(#scan)" opacity="0.55"/>
+  <rect width="320" height="320" fill="url(#vign)"/>
+  <g filter="url(#shadow)">
+    <rect x="18" y="18" width="284" height="284" rx="22" fill="#0a1026" opacity="0.35"/>
+  </g>
+  <rect x="18" y="18" width="284" height="284" rx="22" fill="none" stroke="#4efcff" stroke-opacity="0.40" stroke-width="2" filter="url(#glowC)"/>
+  <rect x="26" y="26" width="268" height="268" rx="18" fill="none" stroke="#ff7a18" stroke-opacity="0.22" stroke-width="1.6" filter="url(#glowO)"/>
+  <g opacity="0.65">
+    <path d="M28 54 h20" stroke="#4efcff" stroke-opacity="0.45" stroke-width="2"/>
+    <path d="M272 54 h20" stroke="#ff7a18" stroke-opacity="0.30" stroke-width="2"/>
+    <path d="M28 266 h20" stroke="#ff7a18" stroke-opacity="0.28" stroke-width="2"/>
+    <path d="M272 266 h20" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"/>
+  </g>
+  <g><circle cx="29" cy="21" r="1.35" fill="#ff7a18" opacity="0.33"/><circle cx="66" cy="74" r="1.9000000000000001" fill="#b36bff" opacity="0.49"/><circle cx="103" cy="127" r="0.8" fill="#ffffff" opacity="0.25"/><circle cx="140" cy="180" r="1.35" fill="#4efcff" opacity="0.41000000000000003"/><circle cx="177" cy="233" r="1.9000000000000001" fill="#ff7a18" opacity="0.5700000000000001"/><circle cx="214" cy="286" r="0.8" fill="#b36bff" opacity="0.33"/><circle cx="251" cy="39" r="1.35" fill="#ffffff" opacity="0.49"/><circle cx="288" cy="92" r="1.9000000000000001" fill="#4efcff" opacity="0.25"/><circle cx="25" cy="145" r="0.8" fill="#ff7a18" opacity="0.41000000000000003"/><circle cx="62" cy="198" r="1.35" fill="#b36bff" opacity="0.5700000000000001"/><circle cx="99" cy="251" r="1.9000000000000001" fill="#ffffff" opacity="0.33"/><circle cx="136" cy="304" r="0.8" fill="#4efcff" opacity="0.49"/><circle cx="173" cy="57" r="1.35" fill="#ff7a18" opacity="0.25"/><circle cx="210" cy="110" r="1.9000000000000001" fill="#b36bff" opacity="0.41000000000000003"/><circle cx="247" cy="163" r="0.8" fill="#ffffff" opacity="0.5700000000000001"/><circle cx="284" cy="216" r="1.35" fill="#4efcff" opacity="0.33"/><circle cx="21" cy="269" r="1.9000000000000001" fill="#ff7a18" opacity="0.49"/><circle cx="58" cy="22" r="0.8" fill="#b36bff" opacity="0.25"/></g>
+  <g transform="translate(160.0,160.0) rotate(23)">
+    <circle r="86" fill="none" stroke="#4efcff" stroke-opacity="0.28" stroke-width="2" filter="url(#glowC)"/>
+    <circle r="104" fill="none" stroke="#ff7a18" stroke-opacity="0.18" stroke-width="1.6" filter="url(#glowO)"/>
+    <path d="M -86 0 A 86 86 0 0 1 0 -86"
+          fill="none" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"
+          stroke-dasharray="4 10" stroke-linecap="round" filter="url(#glowC)"/>
+    <circle r="52" fill="none" stroke="#b36bff" stroke-opacity="0.14" stroke-width="2"/>
+    <g id="orb1">
+      <circle cx="100" cy="0" r="4.0" fill="#4efcff" opacity="0.92" filter="url(#glowC)"/>
+      <circle cx="100" cy="0" r="6.2" fill="none" stroke="#4efcff" stroke-opacity="0.22" stroke-width="2"/>
+      <animateTransform attributeName="transform" type="rotate"
+        from="0 0 0" to="360 0 0" dur="3.35s" repeatCount="indefinite"/>
+    </g>
+  </g>
+  <g transform="translate(26,274)">
+    <rect x="0" y="0" width="132" height="22" rx="11" fill="#0b1024" opacity="0.70" stroke="#4efcff" stroke-opacity="0.18"/>
+    <g transform="translate(10,6)"><rect x="0" y="5" width="10" height="9" rx="2" fill="#4efcff" opacity="0.25"/><rect x="14" y="-4" width="10" height="18" rx="2" fill="#4efcff" opacity="0.32"/><rect x="28" y="8" width="10" height="6" rx="2" fill="#4efcff" opacity="0.39"/><rect x="42" y="-1" width="10" height="15" rx="2" fill="#4efcff" opacity="0.18"/><rect x="56" y="-10" width="10" height="24" rx="2" fill="#4efcff" opacity="0.25"/><rect x="70" y="2" width="10" height="12" rx="2" fill="#4efcff" opacity="0.32"/><rect x="84" y="-7" width="10" height="21" rx="2" fill="#4efcff" opacity="0.39"/><rect x="98" y="5" width="10" height="9" rx="2" fill="#4efcff" opacity="0.18"/><rect x="112" y="-4" width="10" height="18" rx="2" fill="#4efcff" opacity="0.25"/></g>
+    <text x="150" y="16" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="12" fill="#cfe7ff" opacity="0.75">HUB_ANIM_01</text>
+  </g>
 </svg>

--- a/assets/readme/anims/anim_02.svg
+++ b/assets/readme/anims/anim_02.svg
@@ -1,46 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="320" height="320" viewBox="0 0 320 320">
   <defs>
-    <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#050713"/>
       <stop offset="1" stop-color="#0b1430"/>
     </linearGradient>
-    <pattern id="grid2" patternUnits="userSpaceOnUse" width="28" height="28">
+    <radialGradient id="vign" cx="50%" cy="45%" r="75%">
+      <stop offset="0" stop-color="#000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000" stop-opacity="0.55"/>
+    </radialGradient>
+    <pattern id="grid" patternUnits="userSpaceOnUse" width="28" height="28">
       <path d="M28 0H0V28" fill="none" stroke="#7aa7ff" stroke-opacity="0.09" stroke-width="1"/>
     </pattern>
-    <pattern id="scan2" patternUnits="userSpaceOnUse" width="6" height="6">
+    <pattern id="scan" patternUnits="userSpaceOnUse" width="6" height="6">
       <rect width="6" height="6" fill="none"/>
       <rect y="0" width="6" height="1" fill="#ffffff" opacity="0.260"/>
     </pattern>
-    <filter id="glow2" x="-40%" y="-40%" width="180%" height="180%">
+    <filter id="glowC" x="-40%" y="-40%" width="180%" height="180%">
       <feGaussianBlur stdDeviation="3.8" result="b"/>
-      <feComposite in="b" in2="SourceGraphic" operator="over"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0
+                0 1 0 0 0.22
+                0 0 1 0 0.70
+                0 0 0 0.95 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowO" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="4.2" result="b"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0.12
+                0 1 0 0 0.04
+                0 0 1 0 0
+                0 0 0 0.85 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#000" flood-opacity="0.55"/>
     </filter>
   </defs>
-  <!-- background -->
-  <rect width="320" height="320" fill="url(#bg2)"/>
-  <rect width="320" height="320" fill="url(#grid2)"/>
-  <rect width="320" height="320" fill="url(#scan2)"/>
-  <!-- stars -->
-  <circle cx="48" cy="32" r="1.90" fill="#b36bff" opacity="0.41"/><circle cx="85" cy="85" r="0.80" fill="#ffffff" opacity="0.57"/><circle cx="122" cy="138" r="1.35" fill="#4efcff" opacity="0.33"/><circle cx="159" cy="191" r="1.90" fill="#ff7a18" opacity="0.49"/><circle cx="196" cy="244" r="0.80" fill="#b36bff" opacity="0.25"/><circle cx="233" cy="297" r="1.35" fill="#ffffff" opacity="0.41"/><circle cx="270" cy="50" r="1.90" fill="#4efcff" opacity="0.57"/><circle cx="307" cy="103" r="0.80" fill="#ff7a18" opacity="0.33"/><circle cx="44" cy="156" r="1.35" fill="#b36bff" opacity="0.49"/><circle cx="81" cy="209" r="1.90" fill="#ffffff" opacity="0.25"/><circle cx="118" cy="262" r="0.80" fill="#4efcff" opacity="0.41"/><circle cx="155" cy="15" r="1.35" fill="#ff7a18" opacity="0.57"/><circle cx="192" cy="68" r="1.90" fill="#b36bff" opacity="0.33"/><circle cx="229" cy="121" r="0.80" fill="#ffffff" opacity="0.49"/><circle cx="266" cy="174" r="1.35" fill="#4efcff" opacity="0.25"/><circle cx="303" cy="227" r="1.90" fill="#ff7a18" opacity="0.41"/><circle cx="40" cy="280" r="0.80" fill="#b36bff" opacity="0.57"/><circle cx="77" cy="33" r="1.35" fill="#ffffff" opacity="0.33"/>
-  <!-- orbit rings -->
-  <ellipse cx="160.0" cy="160.0" rx="108" ry="84" fill="none" stroke="#4efcff" stroke-opacity="0.18" stroke-width="1.5" stroke-dasharray="4 6"/>
-  <ellipse cx="160.0" cy="160.0" rx="88" ry="70" fill="none" stroke="#ff8c00" stroke-opacity="0.12" stroke-width="1"/>
-  <!-- HUD ticks -->
-  <line x1="248.00" y1="160.00" x2="266.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="241.30" y1="193.68" x2="257.93" y2="200.56" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="222.23" y1="222.23" x2="234.95" y2="234.95" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="193.68" y1="241.30" x2="200.56" y2="257.93" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="248.00" x2="160.00" y2="266.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="126.32" y1="241.30" x2="119.44" y2="257.93" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="97.77" y1="222.23" x2="85.05" y2="234.95" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="78.70" y1="193.68" x2="62.07" y2="200.56" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="72.00" y1="160.00" x2="54.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="78.70" y1="126.32" x2="62.07" y2="119.44" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="97.77" y1="97.77" x2="85.05" y2="85.05" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="126.32" y1="78.70" x2="119.44" y2="62.07" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="72.00" x2="160.00" y2="54.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="193.68" y1="78.70" x2="200.56" y2="62.07" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="222.23" y1="97.77" x2="234.95" y2="85.05" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="241.30" y1="126.32" x2="257.93" y2="119.44" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/>
-  <!-- center sphere -->
-  <circle cx="160.0" cy="160.0" r="22" fill="#0b1a3a" stroke="#4efcff" stroke-opacity="0.5" stroke-width="1.8"/>
-  <circle cx="160.0" cy="160.0" r="8" fill="#4efcff" opacity="0.18"/>
-  <text x="160.0" y="164.0" text-anchor="middle" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.7">CORE</text>
-  <!-- orbiting dot (SMIL) -->
-  <circle cx="268.00" cy="160.00" r="5.5" fill="#4efcff" filter="url(#glow2)">
-    <animateTransform attributeName="transform" type="rotate"
-      from="0 160.0 160.0" to="360 160.0 160.0"
-      dur="3.90s" repeatCount="indefinite"/>
-  </circle>
-  <!-- data bars -->
-  <rect x="26" y="258" width="8" height="12" fill="#4efcff" opacity="0.32" rx="1"/><rect x="40" y="249" width="8" height="21" fill="#4efcff" opacity="0.39" rx="1"/><rect x="54" y="261" width="8" height="9" fill="#4efcff" opacity="0.18" rx="1"/><rect x="68" y="252" width="8" height="18" fill="#4efcff" opacity="0.25" rx="1"/><rect x="82" y="264" width="8" height="6" fill="#4efcff" opacity="0.32" rx="1"/><rect x="96" y="255" width="8" height="15" fill="#4efcff" opacity="0.39" rx="1"/><rect x="110" y="246" width="8" height="24" fill="#4efcff" opacity="0.18" rx="1"/><rect x="124" y="258" width="8" height="12" fill="#4efcff" opacity="0.25" rx="1"/><rect x="138" y="249" width="8" height="21" fill="#4efcff" opacity="0.32" rx="1"/>
-  <!-- label -->
-  <text x="10" y="14" font-family="monospace" font-size="9" fill="#ff8c00" opacity="0.7">SYS-02</text>
-  <text x="10" y="26" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.45">LINUXIA · HUB</text>
+  <rect width="320" height="320" fill="url(#bg)"/>
+  <rect width="320" height="320" fill="url(#grid)"/>
+  <rect width="320" height="320" fill="url(#scan)" opacity="0.55"/>
+  <rect width="320" height="320" fill="url(#vign)"/>
+  <g filter="url(#shadow)">
+    <rect x="18" y="18" width="284" height="284" rx="22" fill="#0a1026" opacity="0.35"/>
+  </g>
+  <rect x="18" y="18" width="284" height="284" rx="22" fill="none" stroke="#4efcff" stroke-opacity="0.40" stroke-width="2" filter="url(#glowC)"/>
+  <rect x="26" y="26" width="268" height="268" rx="18" fill="none" stroke="#ff7a18" stroke-opacity="0.22" stroke-width="1.6" filter="url(#glowO)"/>
+  <g opacity="0.65">
+    <path d="M28 54 h20" stroke="#4efcff" stroke-opacity="0.45" stroke-width="2"/>
+    <path d="M272 54 h20" stroke="#ff7a18" stroke-opacity="0.30" stroke-width="2"/>
+    <path d="M28 266 h20" stroke="#ff7a18" stroke-opacity="0.28" stroke-width="2"/>
+    <path d="M272 266 h20" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"/>
+  </g>
+  <g><circle cx="48" cy="32" r="1.9000000000000001" fill="#b36bff" opacity="0.41000000000000003"/><circle cx="85" cy="85" r="0.8" fill="#ffffff" opacity="0.5700000000000001"/><circle cx="122" cy="138" r="1.35" fill="#4efcff" opacity="0.33"/><circle cx="159" cy="191" r="1.9000000000000001" fill="#ff7a18" opacity="0.49"/><circle cx="196" cy="244" r="0.8" fill="#b36bff" opacity="0.25"/><circle cx="233" cy="297" r="1.35" fill="#ffffff" opacity="0.41000000000000003"/><circle cx="270" cy="50" r="1.9000000000000001" fill="#4efcff" opacity="0.5700000000000001"/><circle cx="307" cy="103" r="0.8" fill="#ff7a18" opacity="0.33"/><circle cx="44" cy="156" r="1.35" fill="#b36bff" opacity="0.49"/><circle cx="81" cy="209" r="1.9000000000000001" fill="#ffffff" opacity="0.25"/><circle cx="118" cy="262" r="0.8" fill="#4efcff" opacity="0.41000000000000003"/><circle cx="155" cy="15" r="1.35" fill="#ff7a18" opacity="0.5700000000000001"/><circle cx="192" cy="68" r="1.9000000000000001" fill="#b36bff" opacity="0.33"/><circle cx="229" cy="121" r="0.8" fill="#ffffff" opacity="0.49"/><circle cx="266" cy="174" r="1.35" fill="#4efcff" opacity="0.25"/><circle cx="303" cy="227" r="1.9000000000000001" fill="#ff7a18" opacity="0.41000000000000003"/><circle cx="40" cy="280" r="0.8" fill="#b36bff" opacity="0.5700000000000001"/><circle cx="77" cy="33" r="1.35" fill="#ffffff" opacity="0.33"/></g>
+  <g transform="translate(160.0,160.0) rotate(46)">
+    <circle r="88" fill="none" stroke="#4efcff" stroke-opacity="0.28" stroke-width="2" filter="url(#glowC)"/>
+    <circle r="106" fill="none" stroke="#ff7a18" stroke-opacity="0.18" stroke-width="1.6" filter="url(#glowO)"/>
+    <path d="M -88 0 A 88 88 0 0 1 0 -88"
+          fill="none" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"
+          stroke-dasharray="4 10" stroke-linecap="round" filter="url(#glowC)"/>
+    <circle r="54" fill="none" stroke="#b36bff" stroke-opacity="0.14" stroke-width="2"/>
+    <g id="orb2">
+      <circle cx="108" cy="0" r="3.2" fill="#4efcff" opacity="0.92" filter="url(#glowC)"/>
+      <circle cx="108" cy="0" r="5.4" fill="none" stroke="#4efcff" stroke-opacity="0.22" stroke-width="2"/>
+      <animateTransform attributeName="transform" type="rotate"
+        from="0 0 0" to="360 0 0" dur="3.90s" repeatCount="indefinite"/>
+    </g>
+  </g>
+  <g transform="translate(26,274)">
+    <rect x="0" y="0" width="132" height="22" rx="11" fill="#0b1024" opacity="0.70" stroke="#4efcff" stroke-opacity="0.18"/>
+    <g transform="translate(10,6)"><rect x="0" y="2" width="10" height="12" rx="2" fill="#4efcff" opacity="0.32"/><rect x="14" y="-7" width="10" height="21" rx="2" fill="#4efcff" opacity="0.39"/><rect x="28" y="5" width="10" height="9" rx="2" fill="#4efcff" opacity="0.18"/><rect x="42" y="-4" width="10" height="18" rx="2" fill="#4efcff" opacity="0.25"/><rect x="56" y="8" width="10" height="6" rx="2" fill="#4efcff" opacity="0.32"/><rect x="70" y="-1" width="10" height="15" rx="2" fill="#4efcff" opacity="0.39"/><rect x="84" y="-10" width="10" height="24" rx="2" fill="#4efcff" opacity="0.18"/><rect x="98" y="2" width="10" height="12" rx="2" fill="#4efcff" opacity="0.25"/><rect x="112" y="-7" width="10" height="21" rx="2" fill="#4efcff" opacity="0.32"/></g>
+    <text x="150" y="16" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="12" fill="#cfe7ff" opacity="0.75">HUB_ANIM_02</text>
+  </g>
 </svg>

--- a/assets/readme/anims/anim_03.svg
+++ b/assets/readme/anims/anim_03.svg
@@ -1,46 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="320" height="320" viewBox="0 0 320 320">
   <defs>
-    <linearGradient id="bg3" x1="0" y1="0" x2="1" y2="1">
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#050713"/>
       <stop offset="1" stop-color="#0b1430"/>
     </linearGradient>
-    <pattern id="grid3" patternUnits="userSpaceOnUse" width="28" height="28">
+    <radialGradient id="vign" cx="50%" cy="45%" r="75%">
+      <stop offset="0" stop-color="#000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000" stop-opacity="0.55"/>
+    </radialGradient>
+    <pattern id="grid" patternUnits="userSpaceOnUse" width="28" height="28">
       <path d="M28 0H0V28" fill="none" stroke="#7aa7ff" stroke-opacity="0.09" stroke-width="1"/>
     </pattern>
-    <pattern id="scan3" patternUnits="userSpaceOnUse" width="6" height="6">
+    <pattern id="scan" patternUnits="userSpaceOnUse" width="6" height="6">
       <rect width="6" height="6" fill="none"/>
       <rect y="0" width="6" height="1" fill="#ffffff" opacity="0.290"/>
     </pattern>
-    <filter id="glow3" x="-40%" y="-40%" width="180%" height="180%">
+    <filter id="glowC" x="-40%" y="-40%" width="180%" height="180%">
       <feGaussianBlur stdDeviation="3.8" result="b"/>
-      <feComposite in="b" in2="SourceGraphic" operator="over"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0
+                0 1 0 0 0.22
+                0 0 1 0 0.70
+                0 0 0 0.95 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowO" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="4.2" result="b"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0.12
+                0 1 0 0 0.04
+                0 0 1 0 0
+                0 0 0 0.85 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#000" flood-opacity="0.55"/>
     </filter>
   </defs>
-  <!-- background -->
-  <rect width="320" height="320" fill="url(#bg3)"/>
-  <rect width="320" height="320" fill="url(#grid3)"/>
-  <rect width="320" height="320" fill="url(#scan3)"/>
-  <!-- stars -->
-  <circle cx="67" cy="43" r="0.80" fill="#ffffff" opacity="0.49"/><circle cx="104" cy="96" r="1.35" fill="#4efcff" opacity="0.25"/><circle cx="141" cy="149" r="1.90" fill="#ff7a18" opacity="0.41"/><circle cx="178" cy="202" r="0.80" fill="#b36bff" opacity="0.57"/><circle cx="215" cy="255" r="1.35" fill="#ffffff" opacity="0.33"/><circle cx="252" cy="308" r="1.90" fill="#4efcff" opacity="0.49"/><circle cx="289" cy="61" r="0.80" fill="#ff7a18" opacity="0.25"/><circle cx="26" cy="114" r="1.35" fill="#b36bff" opacity="0.41"/><circle cx="63" cy="167" r="1.90" fill="#ffffff" opacity="0.57"/><circle cx="100" cy="220" r="0.80" fill="#4efcff" opacity="0.33"/><circle cx="137" cy="273" r="1.35" fill="#ff7a18" opacity="0.49"/><circle cx="174" cy="26" r="1.90" fill="#b36bff" opacity="0.25"/><circle cx="211" cy="79" r="0.80" fill="#ffffff" opacity="0.41"/><circle cx="248" cy="132" r="1.35" fill="#4efcff" opacity="0.57"/><circle cx="285" cy="185" r="1.90" fill="#ff7a18" opacity="0.33"/><circle cx="22" cy="238" r="0.80" fill="#b36bff" opacity="0.49"/><circle cx="59" cy="291" r="1.35" fill="#ffffff" opacity="0.25"/><circle cx="96" cy="44" r="1.90" fill="#4efcff" opacity="0.41"/>
-  <!-- orbit rings -->
-  <ellipse cx="160.0" cy="160.0" rx="116" ry="64" fill="none" stroke="#4efcff" stroke-opacity="0.18" stroke-width="1.5" stroke-dasharray="4 6"/>
-  <ellipse cx="160.0" cy="160.0" rx="96" ry="50" fill="none" stroke="#ff8c00" stroke-opacity="0.12" stroke-width="1"/>
-  <!-- HUD ticks -->
-  <line x1="250.00" y1="160.00" x2="268.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="243.15" y1="194.44" x2="259.78" y2="201.33" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="223.64" y1="223.64" x2="236.37" y2="236.37" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="194.44" y1="243.15" x2="201.33" y2="259.78" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="250.00" x2="160.00" y2="268.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="125.56" y1="243.15" x2="118.67" y2="259.78" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="96.36" y1="223.64" x2="83.63" y2="236.37" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="76.85" y1="194.44" x2="60.22" y2="201.33" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="70.00" y1="160.00" x2="52.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="76.85" y1="125.56" x2="60.22" y2="118.67" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="96.36" y1="96.36" x2="83.63" y2="83.63" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="125.56" y1="76.85" x2="118.67" y2="60.22" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="70.00" x2="160.00" y2="52.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="194.44" y1="76.85" x2="201.33" y2="60.22" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="223.64" y1="96.36" x2="236.37" y2="83.63" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="243.15" y1="125.56" x2="259.78" y2="118.67" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/>
-  <!-- center sphere -->
-  <circle cx="160.0" cy="160.0" r="22" fill="#0b1a3a" stroke="#4efcff" stroke-opacity="0.5" stroke-width="1.8"/>
-  <circle cx="160.0" cy="160.0" r="8" fill="#4efcff" opacity="0.18"/>
-  <text x="160.0" y="164.0" text-anchor="middle" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.7">CORE</text>
-  <!-- orbiting dot (SMIL) -->
-  <circle cx="276.00" cy="160.00" r="5.5" fill="#4efcff" filter="url(#glow3)">
-    <animateTransform attributeName="transform" type="rotate"
-      from="0 160.0 160.0" to="360 160.0 160.0"
-      dur="2.80s" repeatCount="indefinite"/>
-  </circle>
-  <!-- data bars -->
-  <rect x="26" y="255" width="8" height="15" fill="#4efcff" opacity="0.39" rx="1"/><rect x="40" y="246" width="8" height="24" fill="#4efcff" opacity="0.18" rx="1"/><rect x="54" y="258" width="8" height="12" fill="#4efcff" opacity="0.25" rx="1"/><rect x="68" y="249" width="8" height="21" fill="#4efcff" opacity="0.32" rx="1"/><rect x="82" y="261" width="8" height="9" fill="#4efcff" opacity="0.39" rx="1"/><rect x="96" y="252" width="8" height="18" fill="#4efcff" opacity="0.18" rx="1"/><rect x="110" y="264" width="8" height="6" fill="#4efcff" opacity="0.25" rx="1"/><rect x="124" y="255" width="8" height="15" fill="#4efcff" opacity="0.32" rx="1"/><rect x="138" y="246" width="8" height="24" fill="#4efcff" opacity="0.39" rx="1"/>
-  <!-- label -->
-  <text x="10" y="14" font-family="monospace" font-size="9" fill="#ff8c00" opacity="0.7">SYS-03</text>
-  <text x="10" y="26" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.45">LINUXIA · HUB</text>
+  <rect width="320" height="320" fill="url(#bg)"/>
+  <rect width="320" height="320" fill="url(#grid)"/>
+  <rect width="320" height="320" fill="url(#scan)" opacity="0.55"/>
+  <rect width="320" height="320" fill="url(#vign)"/>
+  <g filter="url(#shadow)">
+    <rect x="18" y="18" width="284" height="284" rx="22" fill="#0a1026" opacity="0.35"/>
+  </g>
+  <rect x="18" y="18" width="284" height="284" rx="22" fill="none" stroke="#4efcff" stroke-opacity="0.40" stroke-width="2" filter="url(#glowC)"/>
+  <rect x="26" y="26" width="268" height="268" rx="18" fill="none" stroke="#ff7a18" stroke-opacity="0.22" stroke-width="1.6" filter="url(#glowO)"/>
+  <g opacity="0.65">
+    <path d="M28 54 h20" stroke="#4efcff" stroke-opacity="0.45" stroke-width="2"/>
+    <path d="M272 54 h20" stroke="#ff7a18" stroke-opacity="0.30" stroke-width="2"/>
+    <path d="M28 266 h20" stroke="#ff7a18" stroke-opacity="0.28" stroke-width="2"/>
+    <path d="M272 266 h20" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"/>
+  </g>
+  <g><circle cx="67" cy="43" r="0.8" fill="#ffffff" opacity="0.49"/><circle cx="104" cy="96" r="1.35" fill="#4efcff" opacity="0.25"/><circle cx="141" cy="149" r="1.9000000000000001" fill="#ff7a18" opacity="0.41000000000000003"/><circle cx="178" cy="202" r="0.8" fill="#b36bff" opacity="0.5700000000000001"/><circle cx="215" cy="255" r="1.35" fill="#ffffff" opacity="0.33"/><circle cx="252" cy="308" r="1.9000000000000001" fill="#4efcff" opacity="0.49"/><circle cx="289" cy="61" r="0.8" fill="#ff7a18" opacity="0.25"/><circle cx="26" cy="114" r="1.35" fill="#b36bff" opacity="0.41000000000000003"/><circle cx="63" cy="167" r="1.9000000000000001" fill="#ffffff" opacity="0.5700000000000001"/><circle cx="100" cy="220" r="0.8" fill="#4efcff" opacity="0.33"/><circle cx="137" cy="273" r="1.35" fill="#ff7a18" opacity="0.49"/><circle cx="174" cy="26" r="1.9000000000000001" fill="#b36bff" opacity="0.25"/><circle cx="211" cy="79" r="0.8" fill="#ffffff" opacity="0.41000000000000003"/><circle cx="248" cy="132" r="1.35" fill="#4efcff" opacity="0.5700000000000001"/><circle cx="285" cy="185" r="1.9000000000000001" fill="#ff7a18" opacity="0.33"/><circle cx="22" cy="238" r="0.8" fill="#b36bff" opacity="0.49"/><circle cx="59" cy="291" r="1.35" fill="#ffffff" opacity="0.25"/><circle cx="96" cy="44" r="1.9000000000000001" fill="#4efcff" opacity="0.41000000000000003"/></g>
+  <g transform="translate(160.0,160.0) rotate(69)">
+    <circle r="90" fill="none" stroke="#4efcff" stroke-opacity="0.28" stroke-width="2" filter="url(#glowC)"/>
+    <circle r="108" fill="none" stroke="#ff7a18" stroke-opacity="0.18" stroke-width="1.6" filter="url(#glowO)"/>
+    <path d="M -90 0 A 90 90 0 0 1 0 -90"
+          fill="none" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"
+          stroke-dasharray="4 10" stroke-linecap="round" filter="url(#glowC)"/>
+    <circle r="56" fill="none" stroke="#b36bff" stroke-opacity="0.14" stroke-width="2"/>
+    <g id="orb3">
+      <circle cx="116" cy="0" r="3.2" fill="#4efcff" opacity="0.92" filter="url(#glowC)"/>
+      <circle cx="116" cy="0" r="5.4" fill="none" stroke="#4efcff" stroke-opacity="0.22" stroke-width="2"/>
+      <animateTransform attributeName="transform" type="rotate"
+        from="0 0 0" to="360 0 0" dur="2.80s" repeatCount="indefinite"/>
+    </g>
+  </g>
+  <g transform="translate(26,274)">
+    <rect x="0" y="0" width="132" height="22" rx="11" fill="#0b1024" opacity="0.70" stroke="#4efcff" stroke-opacity="0.18"/>
+    <g transform="translate(10,6)"><rect x="0" y="-1" width="10" height="15" rx="2" fill="#4efcff" opacity="0.39"/><rect x="14" y="-10" width="10" height="24" rx="2" fill="#4efcff" opacity="0.18"/><rect x="28" y="2" width="10" height="12" rx="2" fill="#4efcff" opacity="0.25"/><rect x="42" y="-7" width="10" height="21" rx="2" fill="#4efcff" opacity="0.32"/><rect x="56" y="5" width="10" height="9" rx="2" fill="#4efcff" opacity="0.39"/><rect x="70" y="-4" width="10" height="18" rx="2" fill="#4efcff" opacity="0.18"/><rect x="84" y="8" width="10" height="6" rx="2" fill="#4efcff" opacity="0.25"/><rect x="98" y="-1" width="10" height="15" rx="2" fill="#4efcff" opacity="0.32"/><rect x="112" y="-10" width="10" height="24" rx="2" fill="#4efcff" opacity="0.39"/></g>
+    <text x="150" y="16" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="12" fill="#cfe7ff" opacity="0.75">HUB_ANIM_03</text>
+  </g>
 </svg>

--- a/assets/readme/anims/anim_04.svg
+++ b/assets/readme/anims/anim_04.svg
@@ -1,46 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="320" height="320" viewBox="0 0 320 320">
   <defs>
-    <linearGradient id="bg4" x1="0" y1="0" x2="1" y2="1">
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#050713"/>
       <stop offset="1" stop-color="#0b1430"/>
     </linearGradient>
-    <pattern id="grid4" patternUnits="userSpaceOnUse" width="28" height="28">
+    <radialGradient id="vign" cx="50%" cy="45%" r="75%">
+      <stop offset="0" stop-color="#000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000" stop-opacity="0.55"/>
+    </radialGradient>
+    <pattern id="grid" patternUnits="userSpaceOnUse" width="28" height="28">
       <path d="M28 0H0V28" fill="none" stroke="#7aa7ff" stroke-opacity="0.09" stroke-width="1"/>
     </pattern>
-    <pattern id="scan4" patternUnits="userSpaceOnUse" width="6" height="6">
+    <pattern id="scan" patternUnits="userSpaceOnUse" width="6" height="6">
       <rect width="6" height="6" fill="none"/>
       <rect y="0" width="6" height="1" fill="#ffffff" opacity="0.200"/>
     </pattern>
-    <filter id="glow4" x="-40%" y="-40%" width="180%" height="180%">
+    <filter id="glowC" x="-40%" y="-40%" width="180%" height="180%">
       <feGaussianBlur stdDeviation="3.8" result="b"/>
-      <feComposite in="b" in2="SourceGraphic" operator="over"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0
+                0 1 0 0 0.22
+                0 0 1 0 0.70
+                0 0 0 0.95 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowO" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="4.2" result="b"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0.12
+                0 1 0 0 0.04
+                0 0 1 0 0
+                0 0 0 0.85 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#000" flood-opacity="0.55"/>
     </filter>
   </defs>
-  <!-- background -->
-  <rect width="320" height="320" fill="url(#bg4)"/>
-  <rect width="320" height="320" fill="url(#grid4)"/>
-  <rect width="320" height="320" fill="url(#scan4)"/>
-  <!-- stars -->
-  <circle cx="86" cy="54" r="1.35" fill="#4efcff" opacity="0.57"/><circle cx="123" cy="107" r="1.90" fill="#ff7a18" opacity="0.33"/><circle cx="160" cy="160" r="0.80" fill="#b36bff" opacity="0.49"/><circle cx="197" cy="213" r="1.35" fill="#ffffff" opacity="0.25"/><circle cx="234" cy="266" r="1.90" fill="#4efcff" opacity="0.41"/><circle cx="271" cy="19" r="0.80" fill="#ff7a18" opacity="0.57"/><circle cx="308" cy="72" r="1.35" fill="#b36bff" opacity="0.33"/><circle cx="45" cy="125" r="1.90" fill="#ffffff" opacity="0.49"/><circle cx="82" cy="178" r="0.80" fill="#4efcff" opacity="0.25"/><circle cx="119" cy="231" r="1.35" fill="#ff7a18" opacity="0.41"/><circle cx="156" cy="284" r="1.90" fill="#b36bff" opacity="0.57"/><circle cx="193" cy="37" r="0.80" fill="#ffffff" opacity="0.33"/><circle cx="230" cy="90" r="1.35" fill="#4efcff" opacity="0.49"/><circle cx="267" cy="143" r="1.90" fill="#ff7a18" opacity="0.25"/><circle cx="304" cy="196" r="0.80" fill="#b36bff" opacity="0.41"/><circle cx="41" cy="249" r="1.35" fill="#ffffff" opacity="0.57"/><circle cx="78" cy="302" r="1.90" fill="#4efcff" opacity="0.33"/><circle cx="115" cy="55" r="0.80" fill="#ff7a18" opacity="0.49"/>
-  <!-- orbit rings -->
-  <ellipse cx="160.0" cy="160.0" rx="92" ry="74" fill="none" stroke="#4efcff" stroke-opacity="0.18" stroke-width="1.5" stroke-dasharray="4 6"/>
-  <ellipse cx="160.0" cy="160.0" rx="72" ry="60" fill="none" stroke="#ff8c00" stroke-opacity="0.12" stroke-width="1"/>
-  <!-- HUD ticks -->
-  <line x1="252.00" y1="160.00" x2="270.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="245.00" y1="195.21" x2="261.63" y2="202.10" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="225.05" y1="225.05" x2="237.78" y2="237.78" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="195.21" y1="245.00" x2="202.10" y2="261.63" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="252.00" x2="160.00" y2="270.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="124.79" y1="245.00" x2="117.90" y2="261.63" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="94.95" y1="225.05" x2="82.22" y2="237.78" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="75.00" y1="195.21" x2="58.37" y2="202.10" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="68.00" y1="160.00" x2="50.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="75.00" y1="124.79" x2="58.37" y2="117.90" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="94.95" y1="94.95" x2="82.22" y2="82.22" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="124.79" y1="75.00" x2="117.90" y2="58.37" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="68.00" x2="160.00" y2="50.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="195.21" y1="75.00" x2="202.10" y2="58.37" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="225.05" y1="94.95" x2="237.78" y2="82.22" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="245.00" y1="124.79" x2="261.63" y2="117.90" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/>
-  <!-- center sphere -->
-  <circle cx="160.0" cy="160.0" r="22" fill="#0b1a3a" stroke="#4efcff" stroke-opacity="0.5" stroke-width="1.8"/>
-  <circle cx="160.0" cy="160.0" r="8" fill="#4efcff" opacity="0.18"/>
-  <text x="160.0" y="164.0" text-anchor="middle" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.7">CORE</text>
-  <!-- orbiting dot (SMIL) -->
-  <circle cx="252.00" cy="160.00" r="5.5" fill="#4efcff" filter="url(#glow4)">
-    <animateTransform attributeName="transform" type="rotate"
-      from="0 160.0 160.0" to="360 160.0 160.0"
-      dur="3.35s" repeatCount="indefinite"/>
-  </circle>
-  <!-- data bars -->
-  <rect x="26" y="252" width="8" height="18" fill="#4efcff" opacity="0.18" rx="1"/><rect x="40" y="264" width="8" height="6" fill="#4efcff" opacity="0.25" rx="1"/><rect x="54" y="255" width="8" height="15" fill="#4efcff" opacity="0.32" rx="1"/><rect x="68" y="246" width="8" height="24" fill="#4efcff" opacity="0.39" rx="1"/><rect x="82" y="258" width="8" height="12" fill="#4efcff" opacity="0.18" rx="1"/><rect x="96" y="249" width="8" height="21" fill="#4efcff" opacity="0.25" rx="1"/><rect x="110" y="261" width="8" height="9" fill="#4efcff" opacity="0.32" rx="1"/><rect x="124" y="252" width="8" height="18" fill="#4efcff" opacity="0.39" rx="1"/><rect x="138" y="264" width="8" height="6" fill="#4efcff" opacity="0.18" rx="1"/>
-  <!-- label -->
-  <text x="10" y="14" font-family="monospace" font-size="9" fill="#ff8c00" opacity="0.7">SYS-04</text>
-  <text x="10" y="26" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.45">LINUXIA · HUB</text>
+  <rect width="320" height="320" fill="url(#bg)"/>
+  <rect width="320" height="320" fill="url(#grid)"/>
+  <rect width="320" height="320" fill="url(#scan)" opacity="0.55"/>
+  <rect width="320" height="320" fill="url(#vign)"/>
+  <g filter="url(#shadow)">
+    <rect x="18" y="18" width="284" height="284" rx="22" fill="#0a1026" opacity="0.35"/>
+  </g>
+  <rect x="18" y="18" width="284" height="284" rx="22" fill="none" stroke="#4efcff" stroke-opacity="0.40" stroke-width="2" filter="url(#glowC)"/>
+  <rect x="26" y="26" width="268" height="268" rx="18" fill="none" stroke="#ff7a18" stroke-opacity="0.22" stroke-width="1.6" filter="url(#glowO)"/>
+  <g opacity="0.65">
+    <path d="M28 54 h20" stroke="#4efcff" stroke-opacity="0.45" stroke-width="2"/>
+    <path d="M272 54 h20" stroke="#ff7a18" stroke-opacity="0.30" stroke-width="2"/>
+    <path d="M28 266 h20" stroke="#ff7a18" stroke-opacity="0.28" stroke-width="2"/>
+    <path d="M272 266 h20" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"/>
+  </g>
+  <g><circle cx="86" cy="54" r="1.35" fill="#4efcff" opacity="0.5700000000000001"/><circle cx="123" cy="107" r="1.9000000000000001" fill="#ff7a18" opacity="0.33"/><circle cx="160" cy="160" r="0.8" fill="#b36bff" opacity="0.49"/><circle cx="197" cy="213" r="1.35" fill="#ffffff" opacity="0.25"/><circle cx="234" cy="266" r="1.9000000000000001" fill="#4efcff" opacity="0.41000000000000003"/><circle cx="271" cy="19" r="0.8" fill="#ff7a18" opacity="0.5700000000000001"/><circle cx="308" cy="72" r="1.35" fill="#b36bff" opacity="0.33"/><circle cx="45" cy="125" r="1.9000000000000001" fill="#ffffff" opacity="0.49"/><circle cx="82" cy="178" r="0.8" fill="#4efcff" opacity="0.25"/><circle cx="119" cy="231" r="1.35" fill="#ff7a18" opacity="0.41000000000000003"/><circle cx="156" cy="284" r="1.9000000000000001" fill="#b36bff" opacity="0.5700000000000001"/><circle cx="193" cy="37" r="0.8" fill="#ffffff" opacity="0.33"/><circle cx="230" cy="90" r="1.35" fill="#4efcff" opacity="0.49"/><circle cx="267" cy="143" r="1.9000000000000001" fill="#ff7a18" opacity="0.25"/><circle cx="304" cy="196" r="0.8" fill="#b36bff" opacity="0.41000000000000003"/><circle cx="41" cy="249" r="1.35" fill="#ffffff" opacity="0.5700000000000001"/><circle cx="78" cy="302" r="1.9000000000000001" fill="#4efcff" opacity="0.33"/><circle cx="115" cy="55" r="0.8" fill="#ff7a18" opacity="0.49"/></g>
+  <g transform="translate(160.0,160.0) rotate(92)">
+    <circle r="92" fill="none" stroke="#4efcff" stroke-opacity="0.28" stroke-width="2" filter="url(#glowC)"/>
+    <circle r="110" fill="none" stroke="#ff7a18" stroke-opacity="0.18" stroke-width="1.6" filter="url(#glowO)"/>
+    <path d="M -92 0 A 92 92 0 0 1 0 -92"
+          fill="none" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"
+          stroke-dasharray="4 10" stroke-linecap="round" filter="url(#glowC)"/>
+    <circle r="58" fill="none" stroke="#b36bff" stroke-opacity="0.14" stroke-width="2"/>
+    <g id="orb4">
+      <circle cx="92" cy="0" r="3.2" fill="#4efcff" opacity="0.92" filter="url(#glowC)"/>
+      <circle cx="92" cy="0" r="5.4" fill="none" stroke="#4efcff" stroke-opacity="0.22" stroke-width="2"/>
+      <animateTransform attributeName="transform" type="rotate"
+        from="0 0 0" to="360 0 0" dur="3.35s" repeatCount="indefinite"/>
+    </g>
+  </g>
+  <g transform="translate(26,274)">
+    <rect x="0" y="0" width="132" height="22" rx="11" fill="#0b1024" opacity="0.70" stroke="#4efcff" stroke-opacity="0.18"/>
+    <g transform="translate(10,6)"><rect x="0" y="-4" width="10" height="18" rx="2" fill="#4efcff" opacity="0.18"/><rect x="14" y="8" width="10" height="6" rx="2" fill="#4efcff" opacity="0.25"/><rect x="28" y="-1" width="10" height="15" rx="2" fill="#4efcff" opacity="0.32"/><rect x="42" y="-10" width="10" height="24" rx="2" fill="#4efcff" opacity="0.39"/><rect x="56" y="2" width="10" height="12" rx="2" fill="#4efcff" opacity="0.18"/><rect x="70" y="-7" width="10" height="21" rx="2" fill="#4efcff" opacity="0.25"/><rect x="84" y="5" width="10" height="9" rx="2" fill="#4efcff" opacity="0.32"/><rect x="98" y="-4" width="10" height="18" rx="2" fill="#4efcff" opacity="0.39"/><rect x="112" y="8" width="10" height="6" rx="2" fill="#4efcff" opacity="0.18"/></g>
+    <text x="150" y="16" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="12" fill="#cfe7ff" opacity="0.75">HUB_ANIM_04</text>
+  </g>
 </svg>

--- a/assets/readme/anims/anim_05.svg
+++ b/assets/readme/anims/anim_05.svg
@@ -1,46 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="320" height="320" viewBox="0 0 320 320">
   <defs>
-    <linearGradient id="bg5" x1="0" y1="0" x2="1" y2="1">
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#050713"/>
       <stop offset="1" stop-color="#0b1430"/>
     </linearGradient>
-    <pattern id="grid5" patternUnits="userSpaceOnUse" width="28" height="28">
+    <radialGradient id="vign" cx="50%" cy="45%" r="75%">
+      <stop offset="0" stop-color="#000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000" stop-opacity="0.55"/>
+    </radialGradient>
+    <pattern id="grid" patternUnits="userSpaceOnUse" width="28" height="28">
       <path d="M28 0H0V28" fill="none" stroke="#7aa7ff" stroke-opacity="0.09" stroke-width="1"/>
     </pattern>
-    <pattern id="scan5" patternUnits="userSpaceOnUse" width="6" height="6">
+    <pattern id="scan" patternUnits="userSpaceOnUse" width="6" height="6">
       <rect width="6" height="6" fill="none"/>
       <rect y="0" width="6" height="1" fill="#ffffff" opacity="0.230"/>
     </pattern>
-    <filter id="glow5" x="-40%" y="-40%" width="180%" height="180%">
+    <filter id="glowC" x="-40%" y="-40%" width="180%" height="180%">
       <feGaussianBlur stdDeviation="3.8" result="b"/>
-      <feComposite in="b" in2="SourceGraphic" operator="over"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0
+                0 1 0 0 0.22
+                0 0 1 0 0.70
+                0 0 0 0.95 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowO" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="4.2" result="b"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0.12
+                0 1 0 0 0.04
+                0 0 1 0 0
+                0 0 0 0.85 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#000" flood-opacity="0.55"/>
     </filter>
   </defs>
-  <!-- background -->
-  <rect width="320" height="320" fill="url(#bg5)"/>
-  <rect width="320" height="320" fill="url(#grid5)"/>
-  <rect width="320" height="320" fill="url(#scan5)"/>
-  <!-- stars -->
-  <circle cx="105" cy="65" r="1.90" fill="#ff7a18" opacity="0.25"/><circle cx="142" cy="118" r="0.80" fill="#b36bff" opacity="0.41"/><circle cx="179" cy="171" r="1.35" fill="#ffffff" opacity="0.57"/><circle cx="216" cy="224" r="1.90" fill="#4efcff" opacity="0.33"/><circle cx="253" cy="277" r="0.80" fill="#ff7a18" opacity="0.49"/><circle cx="290" cy="30" r="1.35" fill="#b36bff" opacity="0.25"/><circle cx="27" cy="83" r="1.90" fill="#ffffff" opacity="0.41"/><circle cx="64" cy="136" r="0.80" fill="#4efcff" opacity="0.57"/><circle cx="101" cy="189" r="1.35" fill="#ff7a18" opacity="0.33"/><circle cx="138" cy="242" r="1.90" fill="#b36bff" opacity="0.49"/><circle cx="175" cy="295" r="0.80" fill="#ffffff" opacity="0.25"/><circle cx="212" cy="48" r="1.35" fill="#4efcff" opacity="0.41"/><circle cx="249" cy="101" r="1.90" fill="#ff7a18" opacity="0.57"/><circle cx="286" cy="154" r="0.80" fill="#b36bff" opacity="0.33"/><circle cx="23" cy="207" r="1.35" fill="#ffffff" opacity="0.49"/><circle cx="60" cy="260" r="1.90" fill="#4efcff" opacity="0.25"/><circle cx="97" cy="13" r="0.80" fill="#ff7a18" opacity="0.41"/><circle cx="134" cy="66" r="1.35" fill="#b36bff" opacity="0.57"/>
-  <!-- orbit rings -->
-  <ellipse cx="160.0" cy="160.0" rx="100" ry="84" fill="none" stroke="#4efcff" stroke-opacity="0.18" stroke-width="1.5" stroke-dasharray="4 6"/>
-  <ellipse cx="160.0" cy="160.0" rx="80" ry="70" fill="none" stroke="#ff8c00" stroke-opacity="0.12" stroke-width="1"/>
-  <!-- HUD ticks -->
-  <line x1="254.00" y1="160.00" x2="272.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="246.84" y1="195.97" x2="263.47" y2="202.86" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="226.47" y1="226.47" x2="239.20" y2="239.20" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="195.97" y1="246.84" x2="202.86" y2="263.47" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="254.00" x2="160.00" y2="272.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="124.03" y1="246.84" x2="117.14" y2="263.47" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="93.53" y1="226.47" x2="80.80" y2="239.20" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="73.16" y1="195.97" x2="56.53" y2="202.86" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="66.00" y1="160.00" x2="48.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="73.16" y1="124.03" x2="56.53" y2="117.14" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="93.53" y1="93.53" x2="80.80" y2="80.80" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="124.03" y1="73.16" x2="117.14" y2="56.53" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="66.00" x2="160.00" y2="48.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="195.97" y1="73.16" x2="202.86" y2="56.53" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="226.47" y1="93.53" x2="239.20" y2="80.80" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="246.84" y1="124.03" x2="263.47" y2="117.14" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/>
-  <!-- center sphere -->
-  <circle cx="160.0" cy="160.0" r="22" fill="#0b1a3a" stroke="#4efcff" stroke-opacity="0.5" stroke-width="1.8"/>
-  <circle cx="160.0" cy="160.0" r="8" fill="#4efcff" opacity="0.18"/>
-  <text x="160.0" y="164.0" text-anchor="middle" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.7">CORE</text>
-  <!-- orbiting dot (SMIL) -->
-  <circle cx="260.00" cy="160.00" r="5.5" fill="#4efcff" filter="url(#glow5)">
-    <animateTransform attributeName="transform" type="rotate"
-      from="0 160.0 160.0" to="360 160.0 160.0"
-      dur="3.90s" repeatCount="indefinite"/>
-  </circle>
-  <!-- data bars -->
-  <rect x="26" y="249" width="8" height="21" fill="#4efcff" opacity="0.25" rx="1"/><rect x="40" y="261" width="8" height="9" fill="#4efcff" opacity="0.32" rx="1"/><rect x="54" y="252" width="8" height="18" fill="#4efcff" opacity="0.39" rx="1"/><rect x="68" y="264" width="8" height="6" fill="#4efcff" opacity="0.18" rx="1"/><rect x="82" y="255" width="8" height="15" fill="#4efcff" opacity="0.25" rx="1"/><rect x="96" y="246" width="8" height="24" fill="#4efcff" opacity="0.32" rx="1"/><rect x="110" y="258" width="8" height="12" fill="#4efcff" opacity="0.39" rx="1"/><rect x="124" y="249" width="8" height="21" fill="#4efcff" opacity="0.18" rx="1"/><rect x="138" y="261" width="8" height="9" fill="#4efcff" opacity="0.25" rx="1"/>
-  <!-- label -->
-  <text x="10" y="14" font-family="monospace" font-size="9" fill="#ff8c00" opacity="0.7">SYS-05</text>
-  <text x="10" y="26" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.45">LINUXIA · HUB</text>
+  <rect width="320" height="320" fill="url(#bg)"/>
+  <rect width="320" height="320" fill="url(#grid)"/>
+  <rect width="320" height="320" fill="url(#scan)" opacity="0.55"/>
+  <rect width="320" height="320" fill="url(#vign)"/>
+  <g filter="url(#shadow)">
+    <rect x="18" y="18" width="284" height="284" rx="22" fill="#0a1026" opacity="0.35"/>
+  </g>
+  <rect x="18" y="18" width="284" height="284" rx="22" fill="none" stroke="#4efcff" stroke-opacity="0.40" stroke-width="2" filter="url(#glowC)"/>
+  <rect x="26" y="26" width="268" height="268" rx="18" fill="none" stroke="#ff7a18" stroke-opacity="0.22" stroke-width="1.6" filter="url(#glowO)"/>
+  <g opacity="0.65">
+    <path d="M28 54 h20" stroke="#4efcff" stroke-opacity="0.45" stroke-width="2"/>
+    <path d="M272 54 h20" stroke="#ff7a18" stroke-opacity="0.30" stroke-width="2"/>
+    <path d="M28 266 h20" stroke="#ff7a18" stroke-opacity="0.28" stroke-width="2"/>
+    <path d="M272 266 h20" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"/>
+  </g>
+  <g><circle cx="105" cy="65" r="1.9000000000000001" fill="#ff7a18" opacity="0.25"/><circle cx="142" cy="118" r="0.8" fill="#b36bff" opacity="0.41000000000000003"/><circle cx="179" cy="171" r="1.35" fill="#ffffff" opacity="0.5700000000000001"/><circle cx="216" cy="224" r="1.9000000000000001" fill="#4efcff" opacity="0.33"/><circle cx="253" cy="277" r="0.8" fill="#ff7a18" opacity="0.49"/><circle cx="290" cy="30" r="1.35" fill="#b36bff" opacity="0.25"/><circle cx="27" cy="83" r="1.9000000000000001" fill="#ffffff" opacity="0.41000000000000003"/><circle cx="64" cy="136" r="0.8" fill="#4efcff" opacity="0.5700000000000001"/><circle cx="101" cy="189" r="1.35" fill="#ff7a18" opacity="0.33"/><circle cx="138" cy="242" r="1.9000000000000001" fill="#b36bff" opacity="0.49"/><circle cx="175" cy="295" r="0.8" fill="#ffffff" opacity="0.25"/><circle cx="212" cy="48" r="1.35" fill="#4efcff" opacity="0.41000000000000003"/><circle cx="249" cy="101" r="1.9000000000000001" fill="#ff7a18" opacity="0.5700000000000001"/><circle cx="286" cy="154" r="0.8" fill="#b36bff" opacity="0.33"/><circle cx="23" cy="207" r="1.35" fill="#ffffff" opacity="0.49"/><circle cx="60" cy="260" r="1.9000000000000001" fill="#4efcff" opacity="0.25"/><circle cx="97" cy="13" r="0.8" fill="#ff7a18" opacity="0.41000000000000003"/><circle cx="134" cy="66" r="1.35" fill="#b36bff" opacity="0.5700000000000001"/></g>
+  <g transform="translate(160.0,160.0) rotate(115)">
+    <circle r="94" fill="none" stroke="#4efcff" stroke-opacity="0.28" stroke-width="2" filter="url(#glowC)"/>
+    <circle r="112" fill="none" stroke="#ff7a18" stroke-opacity="0.18" stroke-width="1.6" filter="url(#glowO)"/>
+    <path d="M -94 0 A 94 94 0 0 1 0 -94"
+          fill="none" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"
+          stroke-dasharray="4 10" stroke-linecap="round" filter="url(#glowC)"/>
+    <circle r="60" fill="none" stroke="#b36bff" stroke-opacity="0.14" stroke-width="2"/>
+    <g id="orb5">
+      <circle cx="100" cy="0" r="3.2" fill="#4efcff" opacity="0.92" filter="url(#glowC)"/>
+      <circle cx="100" cy="0" r="5.4" fill="none" stroke="#4efcff" stroke-opacity="0.22" stroke-width="2"/>
+      <animateTransform attributeName="transform" type="rotate"
+        from="0 0 0" to="360 0 0" dur="3.90s" repeatCount="indefinite"/>
+    </g>
+  </g>
+  <g transform="translate(26,274)">
+    <rect x="0" y="0" width="132" height="22" rx="11" fill="#0b1024" opacity="0.70" stroke="#4efcff" stroke-opacity="0.18"/>
+    <g transform="translate(10,6)"><rect x="0" y="-7" width="10" height="21" rx="2" fill="#4efcff" opacity="0.25"/><rect x="14" y="5" width="10" height="9" rx="2" fill="#4efcff" opacity="0.32"/><rect x="28" y="-4" width="10" height="18" rx="2" fill="#4efcff" opacity="0.39"/><rect x="42" y="8" width="10" height="6" rx="2" fill="#4efcff" opacity="0.18"/><rect x="56" y="-1" width="10" height="15" rx="2" fill="#4efcff" opacity="0.25"/><rect x="70" y="-10" width="10" height="24" rx="2" fill="#4efcff" opacity="0.32"/><rect x="84" y="2" width="10" height="12" rx="2" fill="#4efcff" opacity="0.39"/><rect x="98" y="-7" width="10" height="21" rx="2" fill="#4efcff" opacity="0.18"/><rect x="112" y="5" width="10" height="9" rx="2" fill="#4efcff" opacity="0.25"/></g>
+    <text x="150" y="16" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="12" fill="#cfe7ff" opacity="0.75">HUB_ANIM_05</text>
+  </g>
 </svg>

--- a/assets/readme/anims/anim_06.svg
+++ b/assets/readme/anims/anim_06.svg
@@ -1,46 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="320" height="320" viewBox="0 0 320 320">
   <defs>
-    <linearGradient id="bg6" x1="0" y1="0" x2="1" y2="1">
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#050713"/>
       <stop offset="1" stop-color="#0b1430"/>
     </linearGradient>
-    <pattern id="grid6" patternUnits="userSpaceOnUse" width="28" height="28">
+    <radialGradient id="vign" cx="50%" cy="45%" r="75%">
+      <stop offset="0" stop-color="#000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000" stop-opacity="0.55"/>
+    </radialGradient>
+    <pattern id="grid" patternUnits="userSpaceOnUse" width="28" height="28">
       <path d="M28 0H0V28" fill="none" stroke="#7aa7ff" stroke-opacity="0.09" stroke-width="1"/>
     </pattern>
-    <pattern id="scan6" patternUnits="userSpaceOnUse" width="6" height="6">
+    <pattern id="scan" patternUnits="userSpaceOnUse" width="6" height="6">
       <rect width="6" height="6" fill="none"/>
       <rect y="0" width="6" height="1" fill="#ffffff" opacity="0.260"/>
     </pattern>
-    <filter id="glow6" x="-40%" y="-40%" width="180%" height="180%">
+    <filter id="glowC" x="-40%" y="-40%" width="180%" height="180%">
       <feGaussianBlur stdDeviation="3.8" result="b"/>
-      <feComposite in="b" in2="SourceGraphic" operator="over"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0
+                0 1 0 0 0.22
+                0 0 1 0 0.70
+                0 0 0 0.95 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowO" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="4.2" result="b"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0.12
+                0 1 0 0 0.04
+                0 0 1 0 0
+                0 0 0 0.85 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#000" flood-opacity="0.55"/>
     </filter>
   </defs>
-  <!-- background -->
-  <rect width="320" height="320" fill="url(#bg6)"/>
-  <rect width="320" height="320" fill="url(#grid6)"/>
-  <rect width="320" height="320" fill="url(#scan6)"/>
-  <!-- stars -->
-  <circle cx="124" cy="76" r="0.80" fill="#b36bff" opacity="0.33"/><circle cx="161" cy="129" r="1.35" fill="#ffffff" opacity="0.49"/><circle cx="198" cy="182" r="1.90" fill="#4efcff" opacity="0.25"/><circle cx="235" cy="235" r="0.80" fill="#ff7a18" opacity="0.41"/><circle cx="272" cy="288" r="1.35" fill="#b36bff" opacity="0.57"/><circle cx="309" cy="41" r="1.90" fill="#ffffff" opacity="0.33"/><circle cx="46" cy="94" r="0.80" fill="#4efcff" opacity="0.49"/><circle cx="83" cy="147" r="1.35" fill="#ff7a18" opacity="0.25"/><circle cx="120" cy="200" r="1.90" fill="#b36bff" opacity="0.41"/><circle cx="157" cy="253" r="0.80" fill="#ffffff" opacity="0.57"/><circle cx="194" cy="306" r="1.35" fill="#4efcff" opacity="0.33"/><circle cx="231" cy="59" r="1.90" fill="#ff7a18" opacity="0.49"/><circle cx="268" cy="112" r="0.80" fill="#b36bff" opacity="0.25"/><circle cx="305" cy="165" r="1.35" fill="#ffffff" opacity="0.41"/><circle cx="42" cy="218" r="1.90" fill="#4efcff" opacity="0.57"/><circle cx="79" cy="271" r="0.80" fill="#ff7a18" opacity="0.33"/><circle cx="116" cy="24" r="1.35" fill="#b36bff" opacity="0.49"/><circle cx="153" cy="77" r="1.90" fill="#ffffff" opacity="0.25"/>
-  <!-- orbit rings -->
-  <ellipse cx="160.0" cy="160.0" rx="108" ry="64" fill="none" stroke="#4efcff" stroke-opacity="0.18" stroke-width="1.5" stroke-dasharray="4 6"/>
-  <ellipse cx="160.0" cy="160.0" rx="88" ry="50" fill="none" stroke="#ff8c00" stroke-opacity="0.12" stroke-width="1"/>
-  <!-- HUD ticks -->
-  <line x1="256.00" y1="160.00" x2="274.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="248.69" y1="196.74" x2="265.32" y2="203.63" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="227.88" y1="227.88" x2="240.61" y2="240.61" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="196.74" y1="248.69" x2="203.63" y2="265.32" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="256.00" x2="160.00" y2="274.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="123.26" y1="248.69" x2="116.37" y2="265.32" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="92.12" y1="227.88" x2="79.39" y2="240.61" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="71.31" y1="196.74" x2="54.68" y2="203.63" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="64.00" y1="160.00" x2="46.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="71.31" y1="123.26" x2="54.68" y2="116.37" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="92.12" y1="92.12" x2="79.39" y2="79.39" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="123.26" y1="71.31" x2="116.37" y2="54.68" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="64.00" x2="160.00" y2="46.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="196.74" y1="71.31" x2="203.63" y2="54.68" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="227.88" y1="92.12" x2="240.61" y2="79.39" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="248.69" y1="123.26" x2="265.32" y2="116.37" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/>
-  <!-- center sphere -->
-  <circle cx="160.0" cy="160.0" r="22" fill="#0b1a3a" stroke="#4efcff" stroke-opacity="0.5" stroke-width="1.8"/>
-  <circle cx="160.0" cy="160.0" r="8" fill="#4efcff" opacity="0.18"/>
-  <text x="160.0" y="164.0" text-anchor="middle" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.7">CORE</text>
-  <!-- orbiting dot (SMIL) -->
-  <circle cx="268.00" cy="160.00" r="5.5" fill="#4efcff" filter="url(#glow6)">
-    <animateTransform attributeName="transform" type="rotate"
-      from="0 160.0 160.0" to="360 160.0 160.0"
-      dur="2.80s" repeatCount="indefinite"/>
-  </circle>
-  <!-- data bars -->
-  <rect x="26" y="246" width="8" height="24" fill="#4efcff" opacity="0.32" rx="1"/><rect x="40" y="258" width="8" height="12" fill="#4efcff" opacity="0.39" rx="1"/><rect x="54" y="249" width="8" height="21" fill="#4efcff" opacity="0.18" rx="1"/><rect x="68" y="261" width="8" height="9" fill="#4efcff" opacity="0.25" rx="1"/><rect x="82" y="252" width="8" height="18" fill="#4efcff" opacity="0.32" rx="1"/><rect x="96" y="264" width="8" height="6" fill="#4efcff" opacity="0.39" rx="1"/><rect x="110" y="255" width="8" height="15" fill="#4efcff" opacity="0.18" rx="1"/><rect x="124" y="246" width="8" height="24" fill="#4efcff" opacity="0.25" rx="1"/><rect x="138" y="258" width="8" height="12" fill="#4efcff" opacity="0.32" rx="1"/>
-  <!-- label -->
-  <text x="10" y="14" font-family="monospace" font-size="9" fill="#ff8c00" opacity="0.7">SYS-06</text>
-  <text x="10" y="26" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.45">LINUXIA · HUB</text>
+  <rect width="320" height="320" fill="url(#bg)"/>
+  <rect width="320" height="320" fill="url(#grid)"/>
+  <rect width="320" height="320" fill="url(#scan)" opacity="0.55"/>
+  <rect width="320" height="320" fill="url(#vign)"/>
+  <g filter="url(#shadow)">
+    <rect x="18" y="18" width="284" height="284" rx="22" fill="#0a1026" opacity="0.35"/>
+  </g>
+  <rect x="18" y="18" width="284" height="284" rx="22" fill="none" stroke="#4efcff" stroke-opacity="0.40" stroke-width="2" filter="url(#glowC)"/>
+  <rect x="26" y="26" width="268" height="268" rx="18" fill="none" stroke="#ff7a18" stroke-opacity="0.22" stroke-width="1.6" filter="url(#glowO)"/>
+  <g opacity="0.65">
+    <path d="M28 54 h20" stroke="#4efcff" stroke-opacity="0.45" stroke-width="2"/>
+    <path d="M272 54 h20" stroke="#ff7a18" stroke-opacity="0.30" stroke-width="2"/>
+    <path d="M28 266 h20" stroke="#ff7a18" stroke-opacity="0.28" stroke-width="2"/>
+    <path d="M272 266 h20" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"/>
+  </g>
+  <g><circle cx="124" cy="76" r="0.8" fill="#b36bff" opacity="0.33"/><circle cx="161" cy="129" r="1.35" fill="#ffffff" opacity="0.49"/><circle cx="198" cy="182" r="1.9000000000000001" fill="#4efcff" opacity="0.25"/><circle cx="235" cy="235" r="0.8" fill="#ff7a18" opacity="0.41000000000000003"/><circle cx="272" cy="288" r="1.35" fill="#b36bff" opacity="0.5700000000000001"/><circle cx="309" cy="41" r="1.9000000000000001" fill="#ffffff" opacity="0.33"/><circle cx="46" cy="94" r="0.8" fill="#4efcff" opacity="0.49"/><circle cx="83" cy="147" r="1.35" fill="#ff7a18" opacity="0.25"/><circle cx="120" cy="200" r="1.9000000000000001" fill="#b36bff" opacity="0.41000000000000003"/><circle cx="157" cy="253" r="0.8" fill="#ffffff" opacity="0.5700000000000001"/><circle cx="194" cy="306" r="1.35" fill="#4efcff" opacity="0.33"/><circle cx="231" cy="59" r="1.9000000000000001" fill="#ff7a18" opacity="0.49"/><circle cx="268" cy="112" r="0.8" fill="#b36bff" opacity="0.25"/><circle cx="305" cy="165" r="1.35" fill="#ffffff" opacity="0.41000000000000003"/><circle cx="42" cy="218" r="1.9000000000000001" fill="#4efcff" opacity="0.5700000000000001"/><circle cx="79" cy="271" r="0.8" fill="#ff7a18" opacity="0.33"/><circle cx="116" cy="24" r="1.35" fill="#b36bff" opacity="0.49"/><circle cx="153" cy="77" r="1.9000000000000001" fill="#ffffff" opacity="0.25"/></g>
+  <g transform="translate(160.0,160.0) rotate(138)">
+    <circle r="96" fill="none" stroke="#4efcff" stroke-opacity="0.28" stroke-width="2" filter="url(#glowC)"/>
+    <circle r="114" fill="none" stroke="#ff7a18" stroke-opacity="0.18" stroke-width="1.6" filter="url(#glowO)"/>
+    <path d="M -96 0 A 96 96 0 0 1 0 -96"
+          fill="none" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"
+          stroke-dasharray="4 10" stroke-linecap="round" filter="url(#glowC)"/>
+    <circle r="62" fill="none" stroke="#b36bff" stroke-opacity="0.14" stroke-width="2"/>
+    <g id="orb6">
+      <circle cx="108" cy="0" r="4.0" fill="#4efcff" opacity="0.92" filter="url(#glowC)"/>
+      <circle cx="108" cy="0" r="6.2" fill="none" stroke="#4efcff" stroke-opacity="0.22" stroke-width="2"/>
+      <animateTransform attributeName="transform" type="rotate"
+        from="0 0 0" to="360 0 0" dur="2.80s" repeatCount="indefinite"/>
+    </g>
+  </g>
+  <g transform="translate(26,274)">
+    <rect x="0" y="0" width="132" height="22" rx="11" fill="#0b1024" opacity="0.70" stroke="#4efcff" stroke-opacity="0.18"/>
+    <g transform="translate(10,6)"><rect x="0" y="-10" width="10" height="24" rx="2" fill="#4efcff" opacity="0.32"/><rect x="14" y="2" width="10" height="12" rx="2" fill="#4efcff" opacity="0.39"/><rect x="28" y="-7" width="10" height="21" rx="2" fill="#4efcff" opacity="0.18"/><rect x="42" y="5" width="10" height="9" rx="2" fill="#4efcff" opacity="0.25"/><rect x="56" y="-4" width="10" height="18" rx="2" fill="#4efcff" opacity="0.32"/><rect x="70" y="8" width="10" height="6" rx="2" fill="#4efcff" opacity="0.39"/><rect x="84" y="-1" width="10" height="15" rx="2" fill="#4efcff" opacity="0.18"/><rect x="98" y="-10" width="10" height="24" rx="2" fill="#4efcff" opacity="0.25"/><rect x="112" y="2" width="10" height="12" rx="2" fill="#4efcff" opacity="0.32"/></g>
+    <text x="150" y="16" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="12" fill="#cfe7ff" opacity="0.75">HUB_ANIM_06</text>
+  </g>
 </svg>

--- a/assets/readme/anims/anim_07.svg
+++ b/assets/readme/anims/anim_07.svg
@@ -1,46 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="320" height="320" viewBox="0 0 320 320">
   <defs>
-    <linearGradient id="bg7" x1="0" y1="0" x2="1" y2="1">
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#050713"/>
       <stop offset="1" stop-color="#0b1430"/>
     </linearGradient>
-    <pattern id="grid7" patternUnits="userSpaceOnUse" width="28" height="28">
+    <radialGradient id="vign" cx="50%" cy="45%" r="75%">
+      <stop offset="0" stop-color="#000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000" stop-opacity="0.55"/>
+    </radialGradient>
+    <pattern id="grid" patternUnits="userSpaceOnUse" width="28" height="28">
       <path d="M28 0H0V28" fill="none" stroke="#7aa7ff" stroke-opacity="0.09" stroke-width="1"/>
     </pattern>
-    <pattern id="scan7" patternUnits="userSpaceOnUse" width="6" height="6">
+    <pattern id="scan" patternUnits="userSpaceOnUse" width="6" height="6">
       <rect width="6" height="6" fill="none"/>
       <rect y="0" width="6" height="1" fill="#ffffff" opacity="0.290"/>
     </pattern>
-    <filter id="glow7" x="-40%" y="-40%" width="180%" height="180%">
+    <filter id="glowC" x="-40%" y="-40%" width="180%" height="180%">
       <feGaussianBlur stdDeviation="3.8" result="b"/>
-      <feComposite in="b" in2="SourceGraphic" operator="over"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0
+                0 1 0 0 0.22
+                0 0 1 0 0.70
+                0 0 0 0.95 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowO" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="4.2" result="b"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0.12
+                0 1 0 0 0.04
+                0 0 1 0 0
+                0 0 0 0.85 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#000" flood-opacity="0.55"/>
     </filter>
   </defs>
-  <!-- background -->
-  <rect width="320" height="320" fill="url(#bg7)"/>
-  <rect width="320" height="320" fill="url(#grid7)"/>
-  <rect width="320" height="320" fill="url(#scan7)"/>
-  <!-- stars -->
-  <circle cx="143" cy="87" r="1.35" fill="#ffffff" opacity="0.41"/><circle cx="180" cy="140" r="1.90" fill="#4efcff" opacity="0.57"/><circle cx="217" cy="193" r="0.80" fill="#ff7a18" opacity="0.33"/><circle cx="254" cy="246" r="1.35" fill="#b36bff" opacity="0.49"/><circle cx="291" cy="299" r="1.90" fill="#ffffff" opacity="0.25"/><circle cx="28" cy="52" r="0.80" fill="#4efcff" opacity="0.41"/><circle cx="65" cy="105" r="1.35" fill="#ff7a18" opacity="0.57"/><circle cx="102" cy="158" r="1.90" fill="#b36bff" opacity="0.33"/><circle cx="139" cy="211" r="0.80" fill="#ffffff" opacity="0.49"/><circle cx="176" cy="264" r="1.35" fill="#4efcff" opacity="0.25"/><circle cx="213" cy="17" r="1.90" fill="#ff7a18" opacity="0.41"/><circle cx="250" cy="70" r="0.80" fill="#b36bff" opacity="0.57"/><circle cx="287" cy="123" r="1.35" fill="#ffffff" opacity="0.33"/><circle cx="24" cy="176" r="1.90" fill="#4efcff" opacity="0.49"/><circle cx="61" cy="229" r="0.80" fill="#ff7a18" opacity="0.25"/><circle cx="98" cy="282" r="1.35" fill="#b36bff" opacity="0.41"/><circle cx="135" cy="35" r="1.90" fill="#ffffff" opacity="0.57"/><circle cx="172" cy="88" r="0.80" fill="#4efcff" opacity="0.33"/>
-  <!-- orbit rings -->
-  <ellipse cx="160.0" cy="160.0" rx="116" ry="74" fill="none" stroke="#4efcff" stroke-opacity="0.18" stroke-width="1.5" stroke-dasharray="4 6"/>
-  <ellipse cx="160.0" cy="160.0" rx="96" ry="60" fill="none" stroke="#ff8c00" stroke-opacity="0.12" stroke-width="1"/>
-  <!-- HUD ticks -->
-  <line x1="258.00" y1="160.00" x2="276.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="250.54" y1="197.50" x2="267.17" y2="204.39" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="229.30" y1="229.30" x2="242.02" y2="242.02" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="197.50" y1="250.54" x2="204.39" y2="267.17" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="258.00" x2="160.00" y2="276.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="122.50" y1="250.54" x2="115.61" y2="267.17" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="90.70" y1="229.30" x2="77.98" y2="242.02" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="69.46" y1="197.50" x2="52.83" y2="204.39" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="62.00" y1="160.00" x2="44.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="69.46" y1="122.50" x2="52.83" y2="115.61" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="90.70" y1="90.70" x2="77.98" y2="77.98" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="122.50" y1="69.46" x2="115.61" y2="52.83" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="62.00" x2="160.00" y2="44.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="197.50" y1="69.46" x2="204.39" y2="52.83" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="229.30" y1="90.70" x2="242.02" y2="77.98" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="250.54" y1="122.50" x2="267.17" y2="115.61" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/>
-  <!-- center sphere -->
-  <circle cx="160.0" cy="160.0" r="22" fill="#0b1a3a" stroke="#4efcff" stroke-opacity="0.5" stroke-width="1.8"/>
-  <circle cx="160.0" cy="160.0" r="8" fill="#4efcff" opacity="0.18"/>
-  <text x="160.0" y="164.0" text-anchor="middle" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.7">CORE</text>
-  <!-- orbiting dot (SMIL) -->
-  <circle cx="276.00" cy="160.00" r="5.5" fill="#4efcff" filter="url(#glow7)">
-    <animateTransform attributeName="transform" type="rotate"
-      from="0 160.0 160.0" to="360 160.0 160.0"
-      dur="3.35s" repeatCount="indefinite"/>
-  </circle>
-  <!-- data bars -->
-  <rect x="26" y="264" width="8" height="6" fill="#4efcff" opacity="0.39" rx="1"/><rect x="40" y="255" width="8" height="15" fill="#4efcff" opacity="0.18" rx="1"/><rect x="54" y="246" width="8" height="24" fill="#4efcff" opacity="0.25" rx="1"/><rect x="68" y="258" width="8" height="12" fill="#4efcff" opacity="0.32" rx="1"/><rect x="82" y="249" width="8" height="21" fill="#4efcff" opacity="0.39" rx="1"/><rect x="96" y="261" width="8" height="9" fill="#4efcff" opacity="0.18" rx="1"/><rect x="110" y="252" width="8" height="18" fill="#4efcff" opacity="0.25" rx="1"/><rect x="124" y="264" width="8" height="6" fill="#4efcff" opacity="0.32" rx="1"/><rect x="138" y="255" width="8" height="15" fill="#4efcff" opacity="0.39" rx="1"/>
-  <!-- label -->
-  <text x="10" y="14" font-family="monospace" font-size="9" fill="#ff8c00" opacity="0.7">SYS-07</text>
-  <text x="10" y="26" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.45">LINUXIA · HUB</text>
+  <rect width="320" height="320" fill="url(#bg)"/>
+  <rect width="320" height="320" fill="url(#grid)"/>
+  <rect width="320" height="320" fill="url(#scan)" opacity="0.55"/>
+  <rect width="320" height="320" fill="url(#vign)"/>
+  <g filter="url(#shadow)">
+    <rect x="18" y="18" width="284" height="284" rx="22" fill="#0a1026" opacity="0.35"/>
+  </g>
+  <rect x="18" y="18" width="284" height="284" rx="22" fill="none" stroke="#4efcff" stroke-opacity="0.40" stroke-width="2" filter="url(#glowC)"/>
+  <rect x="26" y="26" width="268" height="268" rx="18" fill="none" stroke="#ff7a18" stroke-opacity="0.22" stroke-width="1.6" filter="url(#glowO)"/>
+  <g opacity="0.65">
+    <path d="M28 54 h20" stroke="#4efcff" stroke-opacity="0.45" stroke-width="2"/>
+    <path d="M272 54 h20" stroke="#ff7a18" stroke-opacity="0.30" stroke-width="2"/>
+    <path d="M28 266 h20" stroke="#ff7a18" stroke-opacity="0.28" stroke-width="2"/>
+    <path d="M272 266 h20" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"/>
+  </g>
+  <g><circle cx="143" cy="87" r="1.35" fill="#ffffff" opacity="0.41000000000000003"/><circle cx="180" cy="140" r="1.9000000000000001" fill="#4efcff" opacity="0.5700000000000001"/><circle cx="217" cy="193" r="0.8" fill="#ff7a18" opacity="0.33"/><circle cx="254" cy="246" r="1.35" fill="#b36bff" opacity="0.49"/><circle cx="291" cy="299" r="1.9000000000000001" fill="#ffffff" opacity="0.25"/><circle cx="28" cy="52" r="0.8" fill="#4efcff" opacity="0.41000000000000003"/><circle cx="65" cy="105" r="1.35" fill="#ff7a18" opacity="0.5700000000000001"/><circle cx="102" cy="158" r="1.9000000000000001" fill="#b36bff" opacity="0.33"/><circle cx="139" cy="211" r="0.8" fill="#ffffff" opacity="0.49"/><circle cx="176" cy="264" r="1.35" fill="#4efcff" opacity="0.25"/><circle cx="213" cy="17" r="1.9000000000000001" fill="#ff7a18" opacity="0.41000000000000003"/><circle cx="250" cy="70" r="0.8" fill="#b36bff" opacity="0.5700000000000001"/><circle cx="287" cy="123" r="1.35" fill="#ffffff" opacity="0.33"/><circle cx="24" cy="176" r="1.9000000000000001" fill="#4efcff" opacity="0.49"/><circle cx="61" cy="229" r="0.8" fill="#ff7a18" opacity="0.25"/><circle cx="98" cy="282" r="1.35" fill="#b36bff" opacity="0.41000000000000003"/><circle cx="135" cy="35" r="1.9000000000000001" fill="#ffffff" opacity="0.5700000000000001"/><circle cx="172" cy="88" r="0.8" fill="#4efcff" opacity="0.33"/></g>
+  <g transform="translate(160.0,160.0) rotate(161)">
+    <circle r="98" fill="none" stroke="#4efcff" stroke-opacity="0.28" stroke-width="2" filter="url(#glowC)"/>
+    <circle r="116" fill="none" stroke="#ff7a18" stroke-opacity="0.18" stroke-width="1.6" filter="url(#glowO)"/>
+    <path d="M -98 0 A 98 98 0 0 1 0 -98"
+          fill="none" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"
+          stroke-dasharray="4 10" stroke-linecap="round" filter="url(#glowC)"/>
+    <circle r="64" fill="none" stroke="#b36bff" stroke-opacity="0.14" stroke-width="2"/>
+    <g id="orb7">
+      <circle cx="116" cy="0" r="3.2" fill="#4efcff" opacity="0.92" filter="url(#glowC)"/>
+      <circle cx="116" cy="0" r="5.4" fill="none" stroke="#4efcff" stroke-opacity="0.22" stroke-width="2"/>
+      <animateTransform attributeName="transform" type="rotate"
+        from="0 0 0" to="360 0 0" dur="3.35s" repeatCount="indefinite"/>
+    </g>
+  </g>
+  <g transform="translate(26,274)">
+    <rect x="0" y="0" width="132" height="22" rx="11" fill="#0b1024" opacity="0.70" stroke="#4efcff" stroke-opacity="0.18"/>
+    <g transform="translate(10,6)"><rect x="0" y="8" width="10" height="6" rx="2" fill="#4efcff" opacity="0.39"/><rect x="14" y="-1" width="10" height="15" rx="2" fill="#4efcff" opacity="0.18"/><rect x="28" y="-10" width="10" height="24" rx="2" fill="#4efcff" opacity="0.25"/><rect x="42" y="2" width="10" height="12" rx="2" fill="#4efcff" opacity="0.32"/><rect x="56" y="-7" width="10" height="21" rx="2" fill="#4efcff" opacity="0.39"/><rect x="70" y="5" width="10" height="9" rx="2" fill="#4efcff" opacity="0.18"/><rect x="84" y="-4" width="10" height="18" rx="2" fill="#4efcff" opacity="0.25"/><rect x="98" y="8" width="10" height="6" rx="2" fill="#4efcff" opacity="0.32"/><rect x="112" y="-1" width="10" height="15" rx="2" fill="#4efcff" opacity="0.39"/></g>
+    <text x="150" y="16" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="12" fill="#cfe7ff" opacity="0.75">HUB_ANIM_07</text>
+  </g>
 </svg>

--- a/assets/readme/anims/anim_08.svg
+++ b/assets/readme/anims/anim_08.svg
@@ -1,46 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="320" height="320" viewBox="0 0 320 320">
   <defs>
-    <linearGradient id="bg8" x1="0" y1="0" x2="1" y2="1">
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#050713"/>
       <stop offset="1" stop-color="#0b1430"/>
     </linearGradient>
-    <pattern id="grid8" patternUnits="userSpaceOnUse" width="28" height="28">
+    <radialGradient id="vign" cx="50%" cy="45%" r="75%">
+      <stop offset="0" stop-color="#000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000" stop-opacity="0.55"/>
+    </radialGradient>
+    <pattern id="grid" patternUnits="userSpaceOnUse" width="28" height="28">
       <path d="M28 0H0V28" fill="none" stroke="#7aa7ff" stroke-opacity="0.09" stroke-width="1"/>
     </pattern>
-    <pattern id="scan8" patternUnits="userSpaceOnUse" width="6" height="6">
+    <pattern id="scan" patternUnits="userSpaceOnUse" width="6" height="6">
       <rect width="6" height="6" fill="none"/>
       <rect y="0" width="6" height="1" fill="#ffffff" opacity="0.200"/>
     </pattern>
-    <filter id="glow8" x="-40%" y="-40%" width="180%" height="180%">
+    <filter id="glowC" x="-40%" y="-40%" width="180%" height="180%">
       <feGaussianBlur stdDeviation="3.8" result="b"/>
-      <feComposite in="b" in2="SourceGraphic" operator="over"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0
+                0 1 0 0 0.22
+                0 0 1 0 0.70
+                0 0 0 0.95 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowO" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="4.2" result="b"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0.12
+                0 1 0 0 0.04
+                0 0 1 0 0
+                0 0 0 0.85 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#000" flood-opacity="0.55"/>
     </filter>
   </defs>
-  <!-- background -->
-  <rect width="320" height="320" fill="url(#bg8)"/>
-  <rect width="320" height="320" fill="url(#grid8)"/>
-  <rect width="320" height="320" fill="url(#scan8)"/>
-  <!-- stars -->
-  <circle cx="162" cy="98" r="1.90" fill="#4efcff" opacity="0.49"/><circle cx="199" cy="151" r="0.80" fill="#ff7a18" opacity="0.25"/><circle cx="236" cy="204" r="1.35" fill="#b36bff" opacity="0.41"/><circle cx="273" cy="257" r="1.90" fill="#ffffff" opacity="0.57"/><circle cx="10" cy="10" r="0.80" fill="#4efcff" opacity="0.33"/><circle cx="47" cy="63" r="1.35" fill="#ff7a18" opacity="0.49"/><circle cx="84" cy="116" r="1.90" fill="#b36bff" opacity="0.25"/><circle cx="121" cy="169" r="0.80" fill="#ffffff" opacity="0.41"/><circle cx="158" cy="222" r="1.35" fill="#4efcff" opacity="0.57"/><circle cx="195" cy="275" r="1.90" fill="#ff7a18" opacity="0.33"/><circle cx="232" cy="28" r="0.80" fill="#b36bff" opacity="0.49"/><circle cx="269" cy="81" r="1.35" fill="#ffffff" opacity="0.25"/><circle cx="306" cy="134" r="1.90" fill="#4efcff" opacity="0.41"/><circle cx="43" cy="187" r="0.80" fill="#ff7a18" opacity="0.57"/><circle cx="80" cy="240" r="1.35" fill="#b36bff" opacity="0.33"/><circle cx="117" cy="293" r="1.90" fill="#ffffff" opacity="0.49"/><circle cx="154" cy="46" r="0.80" fill="#4efcff" opacity="0.25"/><circle cx="191" cy="99" r="1.35" fill="#ff7a18" opacity="0.41"/>
-  <!-- orbit rings -->
-  <ellipse cx="160.0" cy="160.0" rx="92" ry="84" fill="none" stroke="#4efcff" stroke-opacity="0.18" stroke-width="1.5" stroke-dasharray="4 6"/>
-  <ellipse cx="160.0" cy="160.0" rx="72" ry="70" fill="none" stroke="#ff8c00" stroke-opacity="0.12" stroke-width="1"/>
-  <!-- HUD ticks -->
-  <line x1="260.00" y1="160.00" x2="278.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="252.39" y1="198.27" x2="269.02" y2="205.16" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="230.71" y1="230.71" x2="243.44" y2="243.44" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="198.27" y1="252.39" x2="205.16" y2="269.02" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="260.00" x2="160.00" y2="278.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="121.73" y1="252.39" x2="114.84" y2="269.02" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="89.29" y1="230.71" x2="76.56" y2="243.44" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="67.61" y1="198.27" x2="50.98" y2="205.16" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="60.00" y1="160.00" x2="42.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="67.61" y1="121.73" x2="50.98" y2="114.84" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="89.29" y1="89.29" x2="76.56" y2="76.56" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="121.73" y1="67.61" x2="114.84" y2="50.98" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="60.00" x2="160.00" y2="42.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="198.27" y1="67.61" x2="205.16" y2="50.98" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="230.71" y1="89.29" x2="243.44" y2="76.56" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="252.39" y1="121.73" x2="269.02" y2="114.84" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/>
-  <!-- center sphere -->
-  <circle cx="160.0" cy="160.0" r="22" fill="#0b1a3a" stroke="#4efcff" stroke-opacity="0.5" stroke-width="1.8"/>
-  <circle cx="160.0" cy="160.0" r="8" fill="#4efcff" opacity="0.18"/>
-  <text x="160.0" y="164.0" text-anchor="middle" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.7">CORE</text>
-  <!-- orbiting dot (SMIL) -->
-  <circle cx="252.00" cy="160.00" r="5.5" fill="#4efcff" filter="url(#glow8)">
-    <animateTransform attributeName="transform" type="rotate"
-      from="0 160.0 160.0" to="360 160.0 160.0"
-      dur="3.90s" repeatCount="indefinite"/>
-  </circle>
-  <!-- data bars -->
-  <rect x="26" y="261" width="8" height="9" fill="#4efcff" opacity="0.18" rx="1"/><rect x="40" y="252" width="8" height="18" fill="#4efcff" opacity="0.25" rx="1"/><rect x="54" y="264" width="8" height="6" fill="#4efcff" opacity="0.32" rx="1"/><rect x="68" y="255" width="8" height="15" fill="#4efcff" opacity="0.39" rx="1"/><rect x="82" y="246" width="8" height="24" fill="#4efcff" opacity="0.18" rx="1"/><rect x="96" y="258" width="8" height="12" fill="#4efcff" opacity="0.25" rx="1"/><rect x="110" y="249" width="8" height="21" fill="#4efcff" opacity="0.32" rx="1"/><rect x="124" y="261" width="8" height="9" fill="#4efcff" opacity="0.39" rx="1"/><rect x="138" y="252" width="8" height="18" fill="#4efcff" opacity="0.18" rx="1"/>
-  <!-- label -->
-  <text x="10" y="14" font-family="monospace" font-size="9" fill="#ff8c00" opacity="0.7">SYS-08</text>
-  <text x="10" y="26" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.45">LINUXIA · HUB</text>
+  <rect width="320" height="320" fill="url(#bg)"/>
+  <rect width="320" height="320" fill="url(#grid)"/>
+  <rect width="320" height="320" fill="url(#scan)" opacity="0.55"/>
+  <rect width="320" height="320" fill="url(#vign)"/>
+  <g filter="url(#shadow)">
+    <rect x="18" y="18" width="284" height="284" rx="22" fill="#0a1026" opacity="0.35"/>
+  </g>
+  <rect x="18" y="18" width="284" height="284" rx="22" fill="none" stroke="#4efcff" stroke-opacity="0.40" stroke-width="2" filter="url(#glowC)"/>
+  <rect x="26" y="26" width="268" height="268" rx="18" fill="none" stroke="#ff7a18" stroke-opacity="0.22" stroke-width="1.6" filter="url(#glowO)"/>
+  <g opacity="0.65">
+    <path d="M28 54 h20" stroke="#4efcff" stroke-opacity="0.45" stroke-width="2"/>
+    <path d="M272 54 h20" stroke="#ff7a18" stroke-opacity="0.30" stroke-width="2"/>
+    <path d="M28 266 h20" stroke="#ff7a18" stroke-opacity="0.28" stroke-width="2"/>
+    <path d="M272 266 h20" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"/>
+  </g>
+  <g><circle cx="162" cy="98" r="1.9000000000000001" fill="#4efcff" opacity="0.49"/><circle cx="199" cy="151" r="0.8" fill="#ff7a18" opacity="0.25"/><circle cx="236" cy="204" r="1.35" fill="#b36bff" opacity="0.41000000000000003"/><circle cx="273" cy="257" r="1.9000000000000001" fill="#ffffff" opacity="0.5700000000000001"/><circle cx="10" cy="10" r="0.8" fill="#4efcff" opacity="0.33"/><circle cx="47" cy="63" r="1.35" fill="#ff7a18" opacity="0.49"/><circle cx="84" cy="116" r="1.9000000000000001" fill="#b36bff" opacity="0.25"/><circle cx="121" cy="169" r="0.8" fill="#ffffff" opacity="0.41000000000000003"/><circle cx="158" cy="222" r="1.35" fill="#4efcff" opacity="0.5700000000000001"/><circle cx="195" cy="275" r="1.9000000000000001" fill="#ff7a18" opacity="0.33"/><circle cx="232" cy="28" r="0.8" fill="#b36bff" opacity="0.49"/><circle cx="269" cy="81" r="1.35" fill="#ffffff" opacity="0.25"/><circle cx="306" cy="134" r="1.9000000000000001" fill="#4efcff" opacity="0.41000000000000003"/><circle cx="43" cy="187" r="0.8" fill="#ff7a18" opacity="0.5700000000000001"/><circle cx="80" cy="240" r="1.35" fill="#b36bff" opacity="0.33"/><circle cx="117" cy="293" r="1.9000000000000001" fill="#ffffff" opacity="0.49"/><circle cx="154" cy="46" r="0.8" fill="#4efcff" opacity="0.25"/><circle cx="191" cy="99" r="1.35" fill="#ff7a18" opacity="0.41000000000000003"/></g>
+  <g transform="translate(160.0,160.0) rotate(4)">
+    <circle r="100" fill="none" stroke="#4efcff" stroke-opacity="0.28" stroke-width="2" filter="url(#glowC)"/>
+    <circle r="118" fill="none" stroke="#ff7a18" stroke-opacity="0.18" stroke-width="1.6" filter="url(#glowO)"/>
+    <path d="M -100 0 A 100 100 0 0 1 0 -100"
+          fill="none" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"
+          stroke-dasharray="4 10" stroke-linecap="round" filter="url(#glowC)"/>
+    <circle r="66" fill="none" stroke="#b36bff" stroke-opacity="0.14" stroke-width="2"/>
+    <g id="orb8">
+      <circle cx="92" cy="0" r="3.2" fill="#4efcff" opacity="0.92" filter="url(#glowC)"/>
+      <circle cx="92" cy="0" r="5.4" fill="none" stroke="#4efcff" stroke-opacity="0.22" stroke-width="2"/>
+      <animateTransform attributeName="transform" type="rotate"
+        from="0 0 0" to="360 0 0" dur="3.90s" repeatCount="indefinite"/>
+    </g>
+  </g>
+  <g transform="translate(26,274)">
+    <rect x="0" y="0" width="132" height="22" rx="11" fill="#0b1024" opacity="0.70" stroke="#4efcff" stroke-opacity="0.18"/>
+    <g transform="translate(10,6)"><rect x="0" y="5" width="10" height="9" rx="2" fill="#4efcff" opacity="0.18"/><rect x="14" y="-4" width="10" height="18" rx="2" fill="#4efcff" opacity="0.25"/><rect x="28" y="8" width="10" height="6" rx="2" fill="#4efcff" opacity="0.32"/><rect x="42" y="-1" width="10" height="15" rx="2" fill="#4efcff" opacity="0.39"/><rect x="56" y="-10" width="10" height="24" rx="2" fill="#4efcff" opacity="0.18"/><rect x="70" y="2" width="10" height="12" rx="2" fill="#4efcff" opacity="0.25"/><rect x="84" y="-7" width="10" height="21" rx="2" fill="#4efcff" opacity="0.32"/><rect x="98" y="5" width="10" height="9" rx="2" fill="#4efcff" opacity="0.39"/><rect x="112" y="-4" width="10" height="18" rx="2" fill="#4efcff" opacity="0.18"/></g>
+    <text x="150" y="16" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="12" fill="#cfe7ff" opacity="0.75">HUB_ANIM_08</text>
+  </g>
 </svg>

--- a/assets/readme/anims/anim_09.svg
+++ b/assets/readme/anims/anim_09.svg
@@ -1,46 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="320" height="320" viewBox="0 0 320 320">
   <defs>
-    <linearGradient id="bg9" x1="0" y1="0" x2="1" y2="1">
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#050713"/>
       <stop offset="1" stop-color="#0b1430"/>
     </linearGradient>
-    <pattern id="grid9" patternUnits="userSpaceOnUse" width="28" height="28">
+    <radialGradient id="vign" cx="50%" cy="45%" r="75%">
+      <stop offset="0" stop-color="#000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000" stop-opacity="0.55"/>
+    </radialGradient>
+    <pattern id="grid" patternUnits="userSpaceOnUse" width="28" height="28">
       <path d="M28 0H0V28" fill="none" stroke="#7aa7ff" stroke-opacity="0.09" stroke-width="1"/>
     </pattern>
-    <pattern id="scan9" patternUnits="userSpaceOnUse" width="6" height="6">
+    <pattern id="scan" patternUnits="userSpaceOnUse" width="6" height="6">
       <rect width="6" height="6" fill="none"/>
       <rect y="0" width="6" height="1" fill="#ffffff" opacity="0.230"/>
     </pattern>
-    <filter id="glow9" x="-40%" y="-40%" width="180%" height="180%">
+    <filter id="glowC" x="-40%" y="-40%" width="180%" height="180%">
       <feGaussianBlur stdDeviation="3.8" result="b"/>
-      <feComposite in="b" in2="SourceGraphic" operator="over"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0
+                0 1 0 0 0.22
+                0 0 1 0 0.70
+                0 0 0 0.95 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowO" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="4.2" result="b"/>
+      <feColorMatrix in="b" type="matrix"
+        values="1 0 0 0 0.12
+                0 1 0 0 0.04
+                0 0 1 0 0
+                0 0 0 0.85 0" result="c"/>
+      <feMerge><feMergeNode in="c"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="10" stdDeviation="10" flood-color="#000" flood-opacity="0.55"/>
     </filter>
   </defs>
-  <!-- background -->
-  <rect width="320" height="320" fill="url(#bg9)"/>
-  <rect width="320" height="320" fill="url(#grid9)"/>
-  <rect width="320" height="320" fill="url(#scan9)"/>
-  <!-- stars -->
-  <circle cx="181" cy="109" r="0.80" fill="#ff7a18" opacity="0.57"/><circle cx="218" cy="162" r="1.35" fill="#b36bff" opacity="0.33"/><circle cx="255" cy="215" r="1.90" fill="#ffffff" opacity="0.49"/><circle cx="292" cy="268" r="0.80" fill="#4efcff" opacity="0.25"/><circle cx="29" cy="21" r="1.35" fill="#ff7a18" opacity="0.41"/><circle cx="66" cy="74" r="1.90" fill="#b36bff" opacity="0.57"/><circle cx="103" cy="127" r="0.80" fill="#ffffff" opacity="0.33"/><circle cx="140" cy="180" r="1.35" fill="#4efcff" opacity="0.49"/><circle cx="177" cy="233" r="1.90" fill="#ff7a18" opacity="0.25"/><circle cx="214" cy="286" r="0.80" fill="#b36bff" opacity="0.41"/><circle cx="251" cy="39" r="1.35" fill="#ffffff" opacity="0.57"/><circle cx="288" cy="92" r="1.90" fill="#4efcff" opacity="0.33"/><circle cx="25" cy="145" r="0.80" fill="#ff7a18" opacity="0.49"/><circle cx="62" cy="198" r="1.35" fill="#b36bff" opacity="0.25"/><circle cx="99" cy="251" r="1.90" fill="#ffffff" opacity="0.41"/><circle cx="136" cy="304" r="0.80" fill="#4efcff" opacity="0.57"/><circle cx="173" cy="57" r="1.35" fill="#ff7a18" opacity="0.33"/><circle cx="210" cy="110" r="1.90" fill="#b36bff" opacity="0.49"/>
-  <!-- orbit rings -->
-  <ellipse cx="160.0" cy="160.0" rx="100" ry="64" fill="none" stroke="#4efcff" stroke-opacity="0.18" stroke-width="1.5" stroke-dasharray="4 6"/>
-  <ellipse cx="160.0" cy="160.0" rx="80" ry="50" fill="none" stroke="#ff8c00" stroke-opacity="0.12" stroke-width="1"/>
-  <!-- HUD ticks -->
-  <line x1="262.00" y1="160.00" x2="280.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="254.24" y1="199.03" x2="270.87" y2="205.92" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="232.12" y1="232.12" x2="244.85" y2="244.85" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="199.03" y1="254.24" x2="205.92" y2="270.87" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="262.00" x2="160.00" y2="280.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="120.97" y1="254.24" x2="114.08" y2="270.87" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="87.88" y1="232.12" x2="75.15" y2="244.85" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="65.76" y1="199.03" x2="49.13" y2="205.92" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="58.00" y1="160.00" x2="40.00" y2="160.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="65.76" y1="120.97" x2="49.13" y2="114.08" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="87.88" y1="87.88" x2="75.15" y2="75.15" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="120.97" y1="65.76" x2="114.08" y2="49.13" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="160.00" y1="58.00" x2="160.00" y2="40.00" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="199.03" y1="65.76" x2="205.92" y2="49.13" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="232.12" y1="87.88" x2="244.85" y2="75.15" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/><line x1="254.24" y1="120.97" x2="270.87" y2="114.08" stroke="#4efcff" stroke-opacity="0.35" stroke-width="1.2"/>
-  <!-- center sphere -->
-  <circle cx="160.0" cy="160.0" r="22" fill="#0b1a3a" stroke="#4efcff" stroke-opacity="0.5" stroke-width="1.8"/>
-  <circle cx="160.0" cy="160.0" r="8" fill="#4efcff" opacity="0.18"/>
-  <text x="160.0" y="164.0" text-anchor="middle" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.7">CORE</text>
-  <!-- orbiting dot (SMIL) -->
-  <circle cx="260.00" cy="160.00" r="5.5" fill="#4efcff" filter="url(#glow9)">
-    <animateTransform attributeName="transform" type="rotate"
-      from="0 160.0 160.0" to="360 160.0 160.0"
-      dur="2.80s" repeatCount="indefinite"/>
-  </circle>
-  <!-- data bars -->
-  <rect x="26" y="258" width="8" height="12" fill="#4efcff" opacity="0.25" rx="1"/><rect x="40" y="249" width="8" height="21" fill="#4efcff" opacity="0.32" rx="1"/><rect x="54" y="261" width="8" height="9" fill="#4efcff" opacity="0.39" rx="1"/><rect x="68" y="252" width="8" height="18" fill="#4efcff" opacity="0.18" rx="1"/><rect x="82" y="264" width="8" height="6" fill="#4efcff" opacity="0.25" rx="1"/><rect x="96" y="255" width="8" height="15" fill="#4efcff" opacity="0.32" rx="1"/><rect x="110" y="246" width="8" height="24" fill="#4efcff" opacity="0.39" rx="1"/><rect x="124" y="258" width="8" height="12" fill="#4efcff" opacity="0.18" rx="1"/><rect x="138" y="249" width="8" height="21" fill="#4efcff" opacity="0.25" rx="1"/>
-  <!-- label -->
-  <text x="10" y="14" font-family="monospace" font-size="9" fill="#ff8c00" opacity="0.7">SYS-09</text>
-  <text x="10" y="26" font-family="monospace" font-size="7" fill="#4efcff" opacity="0.45">LINUXIA · HUB</text>
+  <rect width="320" height="320" fill="url(#bg)"/>
+  <rect width="320" height="320" fill="url(#grid)"/>
+  <rect width="320" height="320" fill="url(#scan)" opacity="0.55"/>
+  <rect width="320" height="320" fill="url(#vign)"/>
+  <g filter="url(#shadow)">
+    <rect x="18" y="18" width="284" height="284" rx="22" fill="#0a1026" opacity="0.35"/>
+  </g>
+  <rect x="18" y="18" width="284" height="284" rx="22" fill="none" stroke="#4efcff" stroke-opacity="0.40" stroke-width="2" filter="url(#glowC)"/>
+  <rect x="26" y="26" width="268" height="268" rx="18" fill="none" stroke="#ff7a18" stroke-opacity="0.22" stroke-width="1.6" filter="url(#glowO)"/>
+  <g opacity="0.65">
+    <path d="M28 54 h20" stroke="#4efcff" stroke-opacity="0.45" stroke-width="2"/>
+    <path d="M272 54 h20" stroke="#ff7a18" stroke-opacity="0.30" stroke-width="2"/>
+    <path d="M28 266 h20" stroke="#ff7a18" stroke-opacity="0.28" stroke-width="2"/>
+    <path d="M272 266 h20" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"/>
+  </g>
+  <g><circle cx="181" cy="109" r="0.8" fill="#ff7a18" opacity="0.5700000000000001"/><circle cx="218" cy="162" r="1.35" fill="#b36bff" opacity="0.33"/><circle cx="255" cy="215" r="1.9000000000000001" fill="#ffffff" opacity="0.49"/><circle cx="292" cy="268" r="0.8" fill="#4efcff" opacity="0.25"/><circle cx="29" cy="21" r="1.35" fill="#ff7a18" opacity="0.41000000000000003"/><circle cx="66" cy="74" r="1.9000000000000001" fill="#b36bff" opacity="0.5700000000000001"/><circle cx="103" cy="127" r="0.8" fill="#ffffff" opacity="0.33"/><circle cx="140" cy="180" r="1.35" fill="#4efcff" opacity="0.49"/><circle cx="177" cy="233" r="1.9000000000000001" fill="#ff7a18" opacity="0.25"/><circle cx="214" cy="286" r="0.8" fill="#b36bff" opacity="0.41000000000000003"/><circle cx="251" cy="39" r="1.35" fill="#ffffff" opacity="0.5700000000000001"/><circle cx="288" cy="92" r="1.9000000000000001" fill="#4efcff" opacity="0.33"/><circle cx="25" cy="145" r="0.8" fill="#ff7a18" opacity="0.49"/><circle cx="62" cy="198" r="1.35" fill="#b36bff" opacity="0.25"/><circle cx="99" cy="251" r="1.9000000000000001" fill="#ffffff" opacity="0.41000000000000003"/><circle cx="136" cy="304" r="0.8" fill="#4efcff" opacity="0.5700000000000001"/><circle cx="173" cy="57" r="1.35" fill="#ff7a18" opacity="0.33"/><circle cx="210" cy="110" r="1.9000000000000001" fill="#b36bff" opacity="0.49"/></g>
+  <g transform="translate(160.0,160.0) rotate(27)">
+    <circle r="102" fill="none" stroke="#4efcff" stroke-opacity="0.28" stroke-width="2" filter="url(#glowC)"/>
+    <circle r="120" fill="none" stroke="#ff7a18" stroke-opacity="0.18" stroke-width="1.6" filter="url(#glowO)"/>
+    <path d="M -102 0 A 102 102 0 0 1 0 -102"
+          fill="none" stroke="#4efcff" stroke-opacity="0.38" stroke-width="2"
+          stroke-dasharray="4 10" stroke-linecap="round" filter="url(#glowC)"/>
+    <circle r="68" fill="none" stroke="#b36bff" stroke-opacity="0.14" stroke-width="2"/>
+    <g id="orb9">
+      <circle cx="100" cy="0" r="4.0" fill="#4efcff" opacity="0.92" filter="url(#glowC)"/>
+      <circle cx="100" cy="0" r="6.2" fill="none" stroke="#4efcff" stroke-opacity="0.22" stroke-width="2"/>
+      <animateTransform attributeName="transform" type="rotate"
+        from="0 0 0" to="360 0 0" dur="2.80s" repeatCount="indefinite"/>
+    </g>
+  </g>
+  <g transform="translate(26,274)">
+    <rect x="0" y="0" width="132" height="22" rx="11" fill="#0b1024" opacity="0.70" stroke="#4efcff" stroke-opacity="0.18"/>
+    <g transform="translate(10,6)"><rect x="0" y="2" width="10" height="12" rx="2" fill="#4efcff" opacity="0.25"/><rect x="14" y="-7" width="10" height="21" rx="2" fill="#4efcff" opacity="0.32"/><rect x="28" y="5" width="10" height="9" rx="2" fill="#4efcff" opacity="0.39"/><rect x="42" y="-4" width="10" height="18" rx="2" fill="#4efcff" opacity="0.18"/><rect x="56" y="8" width="10" height="6" rx="2" fill="#4efcff" opacity="0.25"/><rect x="70" y="-1" width="10" height="15" rx="2" fill="#4efcff" opacity="0.32"/><rect x="84" y="-10" width="10" height="24" rx="2" fill="#4efcff" opacity="0.39"/><rect x="98" y="2" width="10" height="12" rx="2" fill="#4efcff" opacity="0.18"/><rect x="112" y="-7" width="10" height="21" rx="2" fill="#4efcff" opacity="0.25"/></g>
+    <text x="150" y="16" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="12" fill="#cfe7ff" opacity="0.75">HUB_ANIM_09</text>
+  </g>
 </svg>


### PR DESCRIPTION
Régénère 9 SVG 320×320 avec: `glowC`/`glowO` filters, HUD frame, corner ticks, vignette, scanlines, grid, starfield, orbit ring SMIL, data bars. ZERO refs `_score`.