### PR TITLE
meta: repo health (issue templates + conduct + security)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,56 @@
+name: "Bug report"
+description: "Report a reproducible problem (proof-first)."
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting 🙏
+        Please include **proof**: commands + outputs (redact secrets).
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: "Host/VM, OS version, Proxmox/openSUSE versions, kernel, etc."
+      placeholder: "VM100 (openSUSE Leap 16.0), Proxmox VE 9.x, kernel ..."
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: "What were you trying to do?"
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: "Exact steps/commands to reproduce."
+      placeholder: |
+        1) ...
+        2) ...
+        3) ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+    validations:
+      required: true
+  - type: textarea
+    id: proof
+    attributes:
+      label: Proof (logs / command output)
+      description: "Paste relevant logs/output. Redact secrets."
+      render: shell
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/Topbrutus/LinuxIA/security/policy
+    about: Please report security vulnerabilities via the SECURITY policy.
+  - name: Questions / Discussions
+    url: https://github.com/Topbrutus/LinuxIA/discussions
+    about: Ask questions and share ideas here.

--- a/.github/ISSUE_TEMPLATE/docs_request.yml
+++ b/.github/ISSUE_TEMPLATE/docs_request.yml
@@ -1,0 +1,25 @@
+name: "Docs request"
+description: "Documentation improvements or additions."
+title: "[DOCS] "
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What should be documented/changed?
+    validations:
+      required: true
+  - type: textarea
+    id: where
+    attributes:
+      label: Where (file/path/section)?
+      description: "Point to docs/..., README section, or script."
+    validations:
+      required: false
+  - type: textarea
+    id: proof
+    attributes:
+      label: Proof / examples
+      description: "Commands, screenshots, links, expected outcome."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: "Feature request"
+description: "Propose an improvement (proof-first)."
+title: "[FEAT] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the problem, the proposed solution, and acceptance criteria.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: "What problem are we solving?"
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: "What do you want to happen?"
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria (Definition of Done)
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+        - [ ] Proof: ...
+    validations:
+      required: true
+  - type: textarea
+    id: proof
+    attributes:
+      label: Proof / references
+      description: "Links to docs, prior issues, logs, experiments."
+    validations:
+      required: false

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,31 +1,30 @@
 # Code of Conduct
 
-## Notre engagement
+This project follows the Contributor Covenant Code of Conduct (v2.1).
 
-LinuxIA est un projet ouvert et collaboratif. Nous nous engageons à offrir un environnement accueillant, respectueux et sans harcèlement pour tous, peu importe l'origine, l'identité ou le niveau d'expérience.
+## Our Pledge
 
-## Standards attendus
+We pledge to make participation in our community a harassment-free experience for everyone.
 
-**✅ Comportements encouragés:**
-- Respect et bienveillance dans les échanges
-- Critiques constructives sur le code (jamais sur les personnes)
-- Entraide et partage de connaissances
-- Transparence sur les limitations ou erreurs
+## Our Standards
 
-**❌ Comportements inacceptables:**
-- Harcèlement, insultes ou propos discriminatoires
-- Trolling, spam ou sabotage
-- Violation de la vie privée (doxing, partage non-consenti)
-- Tout abus de confiance ou manipulation
+Examples of behavior that contributes to a positive environment include:
 
-## Application
+- Being respectful and constructive
+- Accepting feedback gracefully
+- Focusing on what is best for the community
 
-Les mainteneurs peuvent modérer, éditer ou supprimer les contributions non conformes. Les violations graves entraîneront un bannissement temporaire ou permanent.
+Examples of unacceptable behavior include:
 
-## Signalement
+- Harassment, insults, or personal attacks
+- Publishing others' private information
+- Trolling or disruptive behavior
 
-Contacte [@Topbrutus](https://github.com/Topbrutus) en privé si tu constates un manquement.
+## Enforcement
 
----
+Project maintainers are responsible for clarifying standards and enforcing them.
+To report an incident, use GitHub Issues/Discussions. For security-related matters, follow `SECURITY.md`.
 
-*Inspiré du [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).*
+## Attribution
+
+Contributor Covenant v2.1: https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,40 +1,22 @@
 # Security Policy
 
-## 🛡️ Scope
+## Reporting a Vulnerability
 
-LinuxIA est un projet de recherche en sécurité système. Nous prenons la sécurité au sérieux, mais **ce n'est pas un produit production-ready**.
+Please do **not** open a public issue for security vulnerabilities.
 
-## 🔐 Reporting a vulnerability
+Preferred: GitHub Security Advisories (if enabled for this repository).  
+Fallback: open a **private** channel with the maintainers (use Discussions if private reporting is available).
 
-**Si tu trouves une vulnérabilité critique** (RCE, escalade de privilèges, fuite de secrets):
+## Scope
 
-1. **N'ouvre PAS d'issue publique**
-2. Contacte [@Topbrutus](https://github.com/Topbrutus) en privé via:
-   - GitHub Security Advisory (bouton "Report a vulnerability")
-   - Email (si disponible sur le profil)
-3. Inclus:
-   - Description détaillée (étapes de reproduction)
-   - Impact potentiel (CVSS si applicable)
-   - Suggestion de correctif (si tu en as une)
+In scope:
+- Scripts and tooling in this repository
+- Documentation that may cause unsafe operations if followed
+- VM Factory verification tooling
 
-## ⏱️ Réponse
+Out of scope:
+- Third-party dependencies and external infrastructure not maintained here
 
-- **Accusé réception:** < 72h
-- **Fix + disclosure coordonnée:** selon gravité (7-90 jours)
+## Supported Versions
 
-## 📦 Versions supportées
-
-Seule la branche `main` est activement maintenue. Les branches expérimentales (`phase4-observability`, etc.) ne bénéficient d'aucune garantie de sécurité.
-
-## 🚨 Exceptions
-
-**Vulns acceptées (by design):**
-- Accès SSH non restreint (c'est un lab de recherche)
-- Stockage non-chiffré dans `data/` (documenté dans README)
-- Absence de rate-limiting sur les agents LLM (WIP)
-
-Si tu as un doute → demande avant de signaler !
-
----
-
-**Merci de contribuer à la sécurité de LinuxIA !** 🙏
+Security fixes are provided for the `main` branch.


### PR DESCRIPTION
Repo health baseline — closes #13 #11 #12.

**Inclus :**
- 4 issue templates YAML (bug, feature, docs, config) — proof-first, labels par défaut
- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1
- `SECURITY.md` — scope, supported versions, reporting process

`CONTRIBUTING.md` déjà présent et complet (pas modifié).