### PR TITLE
ci: add smoke-verify workflow + Makefile doctor/lint targets

### DIFF
--- a/.github/workflows/smoke-verify.yml
+++ b/.github/workflows/smoke-verify.yml
@@ -1,0 +1,41 @@
+name: smoke-verify-platform
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    name: Smoke — scripts syntax + shellcheck (read-only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: bash -n (syntax check)
+        run: |
+          bash -n scripts/verify-platform.sh
+          if ls scripts/*.sh >/dev/null 2>&1; then
+            for f in scripts/*.sh; do bash -n "$f"; done
+          fi
+
+      - name: ShellCheck (warnings)
+        continue-on-error: true
+        run: |
+          shellcheck --version
+          if ls scripts/*.sh >/dev/null 2>&1; then
+            shellcheck -x --severity=warning scripts/*.sh
+          fi
+
+      - name: Makefile dry-run (if present)
+        run: |
+          if [ -f Makefile ]; then
+            make -n doctor
+            make -n lint
+          else
+            printf "No Makefile (skip)\n"
+          fi

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+# LinuxIA — Makefile (proof-first)
+# NOTE: Makefile recipes require TAB-indentation.
+SHELL := /usr/bin/env bash
+.DEFAULT_GOAL := help
+
+SCRIPTS_DIR := scripts
+VERIFY      := $(SCRIPTS_DIR)/verify-platform.sh
+
+.PHONY: help
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	  awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-18s\033[0m %s\n",$$1,$$2}'
+
+.PHONY: doctor
+doctor: ## Run platform verification (READ-ONLY)
+	@bash -n "$(VERIFY)"
+	@LINUXIA_READONLY=1 bash "$(VERIFY)" || true
+
+.PHONY: verify
+verify: ## Alias for doctor
+	@$(MAKE) doctor
+
+.PHONY: lint
+lint: ## bash -n + shellcheck on scripts/*.sh (warnings)
+	@set -euo pipefail; \
+	shopt -s nullglob; \
+	for f in $(SCRIPTS_DIR)/*.sh; do \
+	  bash -n "$$f" && printf "  bash -n OK  %s\n" "$$f"; \
+	done; \
+	if command -v shellcheck >/dev/null 2>&1; then \
+	  shellcheck -x --severity=warning $(SCRIPTS_DIR)/*.sh || true; \
+	  printf "  shellcheck done (warnings may remain)\n"; \
+	else \
+	  printf "  WARN: shellcheck not found (install: sudo zypper in ShellCheck)\n"; \
+	fi
+
+.PHONY: syntax
+syntax: ## Fast syntax-only check (bash -n)
+	@set -euo pipefail; \
+	shopt -s nullglob; \
+	for f in $(SCRIPTS_DIR)/*.sh; do \
+	  bash -n "$$f" && printf "  OK  %s\n" "$$f"; \
+	done


### PR DESCRIPTION
## CI Tooling — PR B1

Implements issues #15, #16, #18.

### Changes
- `.github/workflows/smoke-verify.yml`: bash -n syntax + ShellCheck (warnings) + Makefile dry-run on every PR (closes #16)
- `Makefile`: `make doctor` (READ-ONLY `verify-platform.sh`), `make lint`, `make syntax`, `make help` (closes #18)
- `ci.yml` already has ShellCheck + bash-n since repo creation → closes #15 (no change needed)

### Proof
```
make -n doctor → bash -n scripts/verify-platform.sh  ✓
make -n lint   → set -euo pipefail; for f in scripts/*.sh ...  ✓
yaml.safe_load smoke-verify.yml → OK  ✓
```

No secrets. No system writes. No CONTRIBUTING.md touched.