### PR TITLE
docs: start-here + architecture diagram + runbook exit 126

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 **LinuxIA** is a self-hosted, proof-first multi-agent AI platform running on Proxmox VE. Every infrastructure change generates timestamped evidence stored in append-only logs and shared storage. AI proposes — humans validate.
 
+> 🆕 **New here?** → [**docs/start-here.md**](docs/start-here.md) — platform overview, prerequisites, and 3-command quickstart.
+
 ---
 
 ## 🚀 Quick Start

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,92 @@
+# 🏗️ LinuxIA — Architecture
+
+> High-level map of the platform: VMs, data flows, scripts, and CI.
+
+---
+
+## Infrastructure Overview
+
+```mermaid
+graph TD
+    PVE["🖥️ Proxmox VE Host<br/>192.168.1.128"]
+
+    PVE --> VM100["VM100 Factory<br/>192.168.1.135<br/>(main ops, /opt/linuxia)"]
+    PVE --> VM101["VM101 Layer2<br/>192.168.1.136"]
+    PVE --> VM102["VM102 Tool<br/>192.168.1.137"]
+
+    subgraph VM100_internals["VM100 — Factory (openSUSE)"]
+        SCRIPTS["scripts/<br/>verify-platform.sh<br/>linuxia-healthcheck.sh<br/>ci.sh …"]
+        TIMERS["systemd timers<br/>linuxia-*.timer"]
+        LOGS["logs/health/<br/>logs/reports/<br/>(append-only)"]
+        SHARES["data/shareA<br/>data/shareB<br/>(bind mounts)"]
+    end
+
+    VM100 --> VM100_internals
+    SCRIPTS -->|writes proof| LOGS
+    TIMERS -->|triggers| SCRIPTS
+    SCRIPTS -->|archived configs| SHARES
+```
+
+---
+
+## Scripts → Logs Flow
+
+```mermaid
+sequenceDiagram
+    participant Timer as systemd timer
+    participant Script as scripts/*.sh
+    participant Log as logs/health/
+    participant Share as data/shareA/archives/
+
+    Timer->>Script: trigger (scheduled)
+    Script->>Script: run checks (READ-ONLY)
+    Script->>Log: write timestamped proof
+    Script-->>Share: configsnap archive (if changed)
+    Script-->>GitHub: push log summary (optional)
+```
+
+---
+
+## CI / GitHub Actions
+
+```mermaid
+graph LR
+    PR["Pull Request / Push"] --> CI1["ci.yml<br/>bash -n + ShellCheck"]
+    PR --> CI2["smoke-verify.yml<br/>bash -n + ShellCheck<br/>make dry-run"]
+    CI1 -->|pass| Merge["Squash merge to main"]
+    CI2 -->|pass| Merge
+```
+
+All CI jobs are **read-only** — they check syntax, they do not run the scripts against a live system.
+
+---
+
+## Key Paths
+
+| Path | Role |
+|------|------|
+| `/opt/linuxia/scripts/` | All runnable scripts |
+| `/opt/linuxia/logs/health/` | Append-only health logs |
+| `/opt/linuxia/data/shareA/` | Bind-mounted shared storage A |
+| `/opt/linuxia/data/shareB/` | Bind-mounted shared storage B |
+| `/opt/linuxia/data/shareA/archives/configsnap/` | Config snapshots |
+| `/opt/linuxia/services/` | systemd unit templates |
+| `/opt/linuxia/assets/readme/` | README visuals (SVGs, media) |
+| `~gaby/pour_copilot/` | Agent input/output staging area |
+
+---
+
+## Agent Roles (TriluxIA)
+
+| Agent | VM | Role |
+|-------|----|------|
+| Factory | VM100 | Main orchestrator, script runner, log writer |
+| Layer2 | VM101 | Secondary processing, relay |
+| Tool | VM102 | Tooling, builds, utility tasks |
+
+Agents propose changes via `pour_copilot/` → human reviews → merge to `main` → timers apply.
+
+---
+
+→ Detailed script inventory: [`docs/INVENTORY.md`](INVENTORY.md)  
+→ Troubleshooting: [`docs/runbook.md`](runbook.md)

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -520,6 +520,80 @@ sudo setenforce 1
 
 ---
 
+### 🚫 Permission Denied — Exit Code 126
+
+**Symptom**: Script exits with code `126` or `bash: ./scripts/foo.sh: Permission denied`
+
+Exit 126 means the shell found the file but **could not execute it**. Different from exit 127 (file not found).
+
+#### Causes and fixes
+
+**1 — Executable bit missing (most common)**
+```bash
+ls -l scripts/foo.sh
+# If you see -rw-r--r-- (no x), fix with:
+chmod +x scripts/foo.sh
+# Or for the whole scripts/ dir:
+chmod +x scripts/*.sh
+# In git (persists across clones):
+git update-index --chmod=+x scripts/foo.sh
+```
+
+**2 — Wrong shebang or missing shebang**
+```bash
+# Check first line:
+sed -n '1p' scripts/foo.sh
+# Expected: #!/usr/bin/env bash   or   #!/bin/bash
+# If blank or wrong, add: #!/usr/bin/env bash  as first line
+```
+
+**3 — Windows CRLF line endings**
+```bash
+file scripts/foo.sh
+# If output says "CRLF line terminators", strip them:
+sed -i 's/\r$//' scripts/foo.sh
+# Or with dos2unix (if installed):
+dos2unix scripts/foo.sh
+```
+
+**4 — Filesystem mounted noexec**
+```bash
+mount | grep -E "(opt|linuxia|shareA|shareB)"
+# If you see "noexec" in the mount options, the filesystem blocks execution.
+# Fix: remount without noexec (requires root):
+sudo mount -o remount,exec /opt/linuxia
+```
+
+**5 — Wrong file owner / ACL issue**
+```bash
+stat -c "%a %U:%G %n" scripts/foo.sh
+# Expected: 755 gaby:users   (or at least user-executable)
+sudo chown gaby:users scripts/foo.sh
+chmod 755 scripts/foo.sh
+```
+
+**6 — Script run via git on a root-owned object**
+```bash
+# git objects owned by root can block operations:
+sudo chown -R gaby:users /opt/linuxia/.git/objects
+sudo find /opt/linuxia/.git/objects -type d -exec chmod 775 {} \;
+sudo find /opt/linuxia/.git/objects -type f -exec chmod 664 {} \;
+```
+
+#### Quick diagnostic checklist
+
+```bash
+# All-in-one: check executable + shebang + encoding
+f=scripts/verify-platform.sh
+ls -l "$f"
+stat -c "%a %U:%G" "$f"
+sed -n '1p' "$f"
+file "$f"
+mount | grep "$(df -P "$f" | tail -1 | awk '{print $6}')" | grep noexec || printf "noexec: not set\n"
+```
+
+---
+
 ## 📊 Monitoring Checklist
 
 ### Daily (Automated via timers)

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,0 +1,116 @@
+# 🚀 Start Here — LinuxIA in 15 Minutes
+
+> **Audience**: new contributors, ops on VM100, or anyone who just cloned this repo.
+
+---
+
+## What is LinuxIA?
+
+LinuxIA is a **proof-first, multi-agent infrastructure ops platform** running on Proxmox VE.
+
+- Every script generates a timestamped log entry before and after it runs.
+- AI agents (TriluxIA) propose actions — humans validate via the `pour_copilot/` workflow.
+- The platform spans 3 VMs (VM100 Factory, VM101 Layer2, VM102 Tool) and a Proxmox host.
+
+Key rule: **no silent changes**. If a script modifies the system, it writes a proof.
+
+---
+
+## Prerequisites
+
+| Requirement | Details |
+|-------------|---------|
+| Proxmox VE host | `ssh root@192.168.1.128` |
+| VM100 Factory | `ssh gaby@192.168.1.135` — main ops VM |
+| Git access | `git@github.com:Topbrutus/LinuxIA.git` |
+| Repo clone path | `/opt/linuxia` on VM100 |
+| Bash ≥ 4.x | pre-installed on openSUSE |
+
+---
+
+## Quickstart (3 commands)
+
+```bash
+cd /opt/linuxia
+
+# 1 — Check all scripts are syntactically valid
+make syntax
+
+# 2 — Run platform doctor (READ-ONLY — does not write anything)
+make doctor
+
+# 3 — Run full lint (bash -n + shellcheck warnings)
+make lint
+```
+
+Expected output from `make doctor`:
+```
+  bash -n OK  scripts/verify-platform.sh
+  [summary: OK / WARN / FAIL with timestamped log in logs/health/]
+```
+
+If you see `FAIL`: check `logs/health/` for details, then open an issue.
+
+---
+
+## Repository layout (quick map)
+
+```
+/opt/linuxia/
+├── scripts/          # All runnable scripts (verify-platform, ci, healthcheck…)
+├── docs/             # Runbooks, architecture, this file
+├── .github/
+│   ├── workflows/    # CI: ci.yml (ShellCheck) + smoke-verify.yml
+│   └── ISSUE_TEMPLATE/
+├── assets/readme/    # SVGs, gallery, media (README visuals)
+├── services/         # systemd unit files
+├── logs/             # Append-only operation logs (not committed)
+└── Makefile          # Entry point: make help | doctor | lint | syntax
+```
+
+→ Full inventory: [`docs/INVENTORY.md`](INVENTORY.md)  
+→ Architecture diagram: [`docs/architecture.md`](architecture.md)
+
+---
+
+## How to contribute in 15 minutes
+
+1. Pick a [`good first issue`](https://github.com/Topbrutus/LinuxIA/issues?q=label%3A%22good+first+issue%22)
+2. Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)
+3. Create a branch: `git checkout -b fix/my-fix`
+4. Make your change; run `make lint` — it must pass
+5. Open a PR with proof (command + output in the PR body)
+6. Squash merge → done
+
+**Proof-first rule**: every PR must include the terminal output of the change it claims to make.  
+Example: if you fix a script, paste `bash -n scripts/myscript.sh` output in the PR.
+
+---
+
+## Useful one-liners
+
+```bash
+# See all available make targets
+make help
+
+# SSH to VM100 and run doctor
+ssh gaby@192.168.1.135 "cd /opt/linuxia && make doctor"
+
+# Check systemd timers
+ssh gaby@192.168.1.135 "systemctl list-timers linuxia-*"
+
+# View latest health log
+ls -lt /opt/linuxia/logs/health/ | head -5
+
+# Tail CI logs on last push
+gh run list --repo Topbrutus/LinuxIA --limit 3
+gh run view --repo Topbrutus/LinuxIA --log
+```
+
+---
+
+## Stuck?
+
+- Runtime errors → [`docs/runbook.md`](runbook.md)
+- Security issues → [`SECURITY.md`](../SECURITY.md)
+- Questions → [GitHub Discussions](https://github.com/Topbrutus/LinuxIA/discussions) or open an issue


### PR DESCRIPTION
## Docs Wave B2

Closes #10, #14, #17.

### Changes

**`docs/start-here.md`** (closes #10)
- Project overview in plain language
- Prerequisites table (PVE, VM100, git access)
- 3-command quickstart: `make syntax` / `make doctor` / `make lint`
- Repository layout quick-map
- How to contribute in 15 minutes (proof-first rule)
- Useful one-liners for daily ops

**`docs/architecture.md`** (closes #17)
- Mermaid diagram: PVE host → VM100/101/102
- Sequence diagram: timer → script → logs/share flow
- CI pipeline diagram: PR → ci.yml + smoke-verify.yml → merge
- Key paths table

**`docs/runbook.md`** (closes #14)
- New section: *Permission Denied — Exit 126*
- 6 causes: missing executable bit, bad shebang, CRLF endings, noexec mount, wrong owner, root-owned git objects
- All-in-one diagnostic one-liner

**`README.md`**
- Added '🆕 New here?' banner → `docs/start-here.md`

### Proof
```
docs/start-here.md links OK
docs/architecture.md links OK
runbook exit 126 section: present
4 files changed, 284 insertions(+)
```

No code changes. No CI changes. No broken links.