### PR TITLE
tooling: add scripts/linuxia CLI wrapper

### DIFF
--- a/.github/workflows/smoke-verify.yml
+++ b/.github/workflows/smoke-verify.yml
@@ -39,3 +39,9 @@ jobs:
           else
             printf "No Makefile (skip)\n"
           fi
+
+      - name: CLI smoke (scripts/linuxia)
+        run: |
+          bash -n scripts/linuxia
+          ./scripts/linuxia help >/dev/null
+          ./scripts/linuxia version || true

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -35,12 +35,15 @@ cd /opt/linuxia
 
 # 1 — Check all scripts are syntactically valid
 make syntax
+# or: ./scripts/linuxia syntax
 
 # 2 — Run platform doctor (READ-ONLY — does not write anything)
 make doctor
+# or: ./scripts/linuxia doctor
 
 # 3 — Run full lint (bash -n + shellcheck warnings)
 make lint
+# or: ./scripts/linuxia lint
 ```
 
 Expected output from `make doctor`:

--- a/scripts/linuxia
+++ b/scripts/linuxia
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+usage() {
+  printf "LinuxIA CLI (proof-first)\n\n"
+  printf "Usage:\n"
+  printf "  scripts/linuxia <command>\n\n"
+  printf "Commands:\n"
+  printf "  help        Show this help\n"
+  printf "  doctor      Run read-only platform verification (make doctor)\n"
+  printf "  lint        Run bash syntax + shellcheck warnings (make lint)\n"
+  printf "  syntax      Fast bash syntax-only checks (make syntax)\n"
+  printf "  verify      Alias for doctor\n"
+  printf "  version     Show git version info\n\n"
+  printf "Notes:\n"
+  printf "  - This CLI is read-only by default.\n"
+  printf "  - Prefer running from the repo root.\n"
+}
+
+cmd="${1:-help}"
+
+case "$cmd" in
+  help|-h|--help)
+    usage
+    ;;
+  doctor|verify)
+    [ -f Makefile ] || die "Makefile not found at repo root"
+    make doctor
+    ;;
+  lint)
+    [ -f Makefile ] || die "Makefile not found at repo root"
+    make lint
+    ;;
+  syntax)
+    [ -f Makefile ] || die "Makefile not found at repo root"
+    make syntax
+    ;;
+  version)
+    if have git && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      printf "LinuxIA repo: %s\n" "$(git rev-parse --show-toplevel 2>/dev/null || printf ".")"
+      printf "Branch:       %s\n" "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || printf "unknown")"
+      printf "Commit:       %s\n" "$(git rev-parse --short HEAD 2>/dev/null || printf "unknown")"
+      if git diff --quiet && git diff --cached --quiet 2>/dev/null; then
+        printf "Dirty:        no\n"
+      else
+        printf "Dirty:        yes\n"
+      fi
+    else
+      printf "git not available (or not a git repo)\n"
+    fi
+    ;;
+  *)
+    die "Unknown command: $cmd (try: scripts/linuxia help)"
+    ;;
+esac


### PR DESCRIPTION
Adds a unified CLI entry point wrapping Makefile targets.

## Changes

**`scripts/linuxia`** (new, chmod +x)
- `./scripts/linuxia doctor` → `make doctor` (READ-ONLY verify-platform)
- `./scripts/linuxia lint` → `make lint` (bash-n + ShellCheck)
- `./scripts/linuxia syntax` → `make syntax` (bash-n only)
- `./scripts/linuxia version` → branch + commit + dirty state
- `./scripts/linuxia help` → usage

**`smoke-verify.yml`** — new step: `bash -n scripts/linuxia` + `./scripts/linuxia help` + `version`

**`docs/start-here.md`** — quickstart shows both `make` and `./scripts/linuxia` forms

## Proof
```
bash -n scripts/linuxia        ✓
./scripts/linuxia syntax       26 scripts OK
./scripts/linuxia lint         26 bash-n OK + ShellCheck warn (absent locally, covered by CI)
./scripts/linuxia version      branch + commit ✓
```

Read-only. No sudo. No system mutations.