### PR TITLE
tooling: add .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# LinuxIA — CODEOWNERS
+# Objectif: exiger une review explicite sur les chemins critiques
+
+# Gouvernance / sécurité
+SECURITY.md                 @Topbrutus
+RISKS.md                    @Topbrutus
+
+# CI/CD et automatisation
+.github/workflows/*         @Topbrutus
+
+# Scripts d'orchestration (impact infra)
+scripts/*                   @Topbrutus
+scripts/**                  @Topbrutus
+
+# README / vitrine (évite les régressions de présentation)
+README.md                   @Topbrutus
+assets/**                   @Topbrutus


### PR DESCRIPTION
Adds CODEOWNERS to enforce explicit reviews on critical paths.

## Coverage

| Path | Owner |
|------|-------|
| `SECURITY.md`, `RISKS.md` | @Topbrutus |
| `.github/workflows/*` | @Topbrutus |
| `scripts/*`, `scripts/**` | @Topbrutus |
| `README.md`, `assets/**` | @Topbrutus |

Works with the branch protection rule (require code owner reviews) — activate via `require_code_owner_reviews: true` in protection settings when ready to enforce.