### PR TITLE
docs(vitrine): cinematic cards vNext — 1600×520 banner + parallax + subtitle reveal

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,3 +463,35 @@ Pipelines opérationnels déterministes
 License / Licence 📄
 
 To be defined / À définir.
+
+<!-- LINUXIA_CINEMATIC_CARDS_BEGIN -->
+
+## 🎞️ Vitrine — Cinematic Cards (GitHub-safe, 0 JS)
+
+<p align="center">
+  <img src="assets/readme/cinematic/cards/section_gallery_01.svg" width="100%" alt="Vision &amp; Platform"/>
+</p>
+<p align="center">
+  <img src="assets/readme/cinematic/cards/section_gallery_02.svg" width="100%" alt="Architecture"/>
+</p>
+<p align="center">
+  <img src="assets/readme/cinematic/cards/section_gallery_03.svg" width="100%" alt="Agents TriluxIA"/>
+</p>
+<p align="center">
+  <img src="assets/readme/cinematic/cards/section_gallery_04.svg" width="100%" alt="Immutable Proof"/>
+</p>
+<p align="center">
+  <img src="assets/readme/cinematic/cards/section_gallery_05.svg" width="100%" alt="Infra &amp; Timers"/>
+</p>
+<p align="center">
+  <img src="assets/readme/cinematic/cards/section_gallery_06.svg" width="100%" alt="Security"/>
+</p>
+<p align="center">
+  <img src="assets/readme/cinematic/cards/section_gallery_07.svg" width="100%" alt="Storage &amp; Shares"/>
+</p>
+<p align="center">
+  <img src="assets/readme/cinematic/cards/section_gallery_08.svg" width="100%" alt="Roadmap"/>
+</p>
+
+<!-- LINUXIA_CINEMATIC_CARDS_END -->
+


### PR DESCRIPTION
## Cinematic Cards vNext

### Changes
- **Canvas**: 1600×720 → **1600×520** (banner format, 28% slimmer)
- **Parallax 4-layer**:
  - Layer 1: photo drift `dur=11s` (slow, deep)
  - Layer 2: scanlines+vignette counter-drift `dur=7.5s` (opposite vector)
  - Layer 3: shimmer sweep mask `dur=5.5s`
  - Layer 4: 5 dust particles `dur=9–16s`, opacity ≤0.18
- **Subtitle reveal**: mask rect `0→420px` over 1.1s (`begin=0.3s, fill=freeze`)
- **Hyperline**: fades in at 0.9s (after reveal), then oscillates
- **Corner brackets**: staggered breathing opacity per chip

### Validation
- 8/8 cards: `viewBox="0 0 1600 520"` ✅
- 0 `<script>` / `javascript` occurrences ✅
- 8/8 cards: `animateTransform` present ✅
- 8/8 cards: `mSub` (subtitle reveal mask) present ✅
- SMIL-only, GitHub-safe